### PR TITLE
[codex] Harden broker and add threaded message history

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,11 @@ A walkie-talkie for Claude, Codex, Gemini and z.ai to talk to each other, coordi
 - Codex Desktop *can* join, but you probably should use Codex CLI. It can still talk, but you have to tell it to do so.
 - Gemini CLI can join through `.gemini/settings.json` or `gemini mcp add`.
 - Antigravity *can* join through its raw `mcp_config.json`. Same problem with Codex Desktop.
-- Everyagent can join over plain HTTP.
+- Every agent can join over plain HTTP.
 - Everyone shares the same local registry, heartbeat loop, and message queue.
+- Agents now track unread counts, delivery state, launcher metadata, and notification style hints.
+- Messages can now stay grouped into conversations with reply links and retrievable thread history.
+- Agent-scoped actions are now authenticated with per-agent broker tokens, and the broker uses schema-versioned migrations plus a startup lock to keep launches predictable.
 
 ```text
 Claude Code session            HTTP agent              Another Claude session
@@ -107,8 +110,11 @@ enabled = true
 
 - `codex-server.ts` registers Codex as an `openai-codex` agent on the same broker.
 - Codex gets `list_agents`, `send_message`, `set_summary`, and `check_messages`.
-- Unlike Claude Code, Codex does not use the Claude channel push path in this integration. Instead, `claudy-talky` polls in the background and emits standard MCP log notifications when the client supports them, with `check_messages` kept as the fallback inbox.
+- Unlike Claude Code, Codex does not use the Claude channel push path in this integration. Instead, `claudy-talky` polls in the background, emits standard MCP log notifications when the client supports them, and also attempts a local desktop notification fallback. `check_messages` remains the fallback inbox and now marks messages as seen.
+- Codex can keep threaded replies together by sending `reply_to_message_id` or `conversation_id`, and it can revisit older threads with `message_history`.
 - `claudy-talky` now also asks MCP-capable Codex clients for workspace roots after connect, so Codex CLI sessions can register the actual project path instead of a generic launcher cwd such as `C:\Windows\System32`.
+- `list_agents` now shows inbox counts plus richer metadata such as launcher type, workspace source, and supported notification styles.
+- Codex and the other bundled adapters automatically carry the broker auth token returned during registration, so the secured broker flow stays transparent in normal use.
 
 ### Practical workflow
 
@@ -148,7 +154,8 @@ gemini mcp add claudy-talky-gemini bun ./google-server.ts --client gemini
 
 - Gemini registers as a `google-gemini` agent.
 - It gets `list_agents`, `send_message`, `set_summary`, and `check_messages`.
-- Like Codex, it uses background inbox polling plus standard MCP log notifications when the client supports them, with `check_messages` as the fallback inbox.
+- Like Codex, it uses background inbox polling plus standard MCP log notifications when the client supports them, with desktop notifications as a best-effort fallback and `check_messages` as the fallback inbox.
+- Gemini can also use `message_history` plus `reply_to_message_id` / `conversation_id` to stay inside a thread.
 
 ## Connect Antigravity
 
@@ -173,7 +180,8 @@ If Antigravity stores that raw config outside this repo, replace `./google-serve
 
 - Antigravity registers as a `google-antigravity` agent.
 - It uses the same tool surface as Gemini: `list_agents`, `send_message`, `set_summary`, and `check_messages`.
-- It uses the same background inbox polling path as Gemini, with standard MCP log notifications when the client supports them and `check_messages` as the fallback inbox.
+- It uses the same background inbox polling path as Gemini, with standard MCP log notifications when the client supports them, desktop notifications as a best-effort fallback, and `check_messages` as the fallback inbox.
+- Antigravity can also use `message_history` plus `reply_to_message_id` / `conversation_id` to stay inside a thread.
 
 ## z.ai Note
 
@@ -185,6 +193,7 @@ z.ai looks possible as a provider layer, but not yet as a first-class `claudy-ta
 | --- | --- |
 | `list_agents` | Discover connected agents on this machine, in this directory, or in this repo |
 | `send_message` | Send a message to another agent by ID |
+| `message_history` | Revisit recent messages, optionally filtered to one agent or one conversation |
 | `set_summary` | Publish a short description of Claude's current work |
 | `check_messages` | Manually check for inbound messages |
 | `list_peers` | Backward-compatible alias for `list_agents` |
@@ -204,6 +213,8 @@ This example:
 - registers as a `custom-http-agent`
 - heartbeats every 15 seconds
 - polls for inbound messages every second
+- stores the broker auth token returned at registration
+- marks messages as seen after reading them
 - replies with an acknowledgement
 
 ### Minimal protocol
@@ -222,12 +233,14 @@ curl -X POST http://127.0.0.1:7899/register-agent \
   }'
 ```
 
+The broker returns a short-lived agent identity plus an `auth_token`. Keep both.
+
 Heartbeat:
 
 ```bash
 curl -X POST http://127.0.0.1:7899/heartbeat \
   -H "Content-Type: application/json" \
-  -d '{"id":"<agent-id>"}'
+  -d '{"id":"<agent-id>","auth_token":"<auth-token>"}'
 ```
 
 List agents:
@@ -246,16 +259,51 @@ curl -X POST http://127.0.0.1:7899/send-message \
   -d '{
     "from_id":"<agent-id>",
     "to_id":"<target-id>",
-    "text":"Hello from a custom agent."
+    "text":"Hello from a custom agent.",
+    "conversation_id":"<optional-conversation-id>",
+    "reply_to_message_id":123,
+    "auth_token":"<auth-token>"
   }'
 ```
+
+`conversation_id` and `reply_to_message_id` are optional. Use `reply_to_message_id` when you want to reply inside an existing thread. The broker responds with `ok` plus a message record including the assigned message ID, thread metadata, and delivery state.
 
 Poll messages:
 
 ```bash
 curl -X POST http://127.0.0.1:7899/poll-messages \
   -H "Content-Type: application/json" \
-  -d '{"id":"<agent-id>"}'
+  -d '{"id":"<agent-id>","auth_token":"<auth-token>"}'
+```
+
+Mark messages as surfaced after your client displays them or otherwise surfaces them to the user:
+
+```bash
+curl -X POST http://127.0.0.1:7899/mark-messages-surfaced \
+  -H "Content-Type: application/json" \
+  -d '{"id":"<agent-id>","message_ids":[1,2,3],"auth_token":"<auth-token>"}'
+```
+
+Mark messages as seen after your agent actually reviews them:
+
+```bash
+curl -X POST http://127.0.0.1:7899/acknowledge-messages \
+  -H "Content-Type: application/json" \
+  -d '{"id":"<agent-id>","message_ids":[1,2,3],"auth_token":"<auth-token>"}'
+```
+
+Retrieve recent message history:
+
+```bash
+curl -X POST http://127.0.0.1:7899/message-history \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agent_id":"<agent-id>",
+    "with_agent_id":"<optional-other-agent-id>",
+    "conversation_id":"<optional-conversation-id>",
+    "limit":20,
+    "auth_token":"<auth-token>"
+  }'
 ```
 
 Unregister:
@@ -263,17 +311,21 @@ Unregister:
 ```bash
 curl -X POST http://127.0.0.1:7899/unregister \
   -H "Content-Type: application/json" \
-  -d '{"id":"<agent-id>"}'
+  -d '{"id":"<agent-id>","auth_token":"<auth-token>"}'
 ```
 
 ## Architecture
 
 - `broker.ts` runs a localhost-only HTTP broker backed by SQLite.
-- `server.ts` is the Claude adapter. It exposes MCP tools and turns inbound messages into Claude channel notifications.
-- `codex-server.ts` is the Codex adapter. It exposes the same broker tools without relying on Claude-specific channel push.
-- `google-server.ts` is the Gemini CLI and Antigravity adapter. It exposes the same broker tools with background inbox polling.
+- `broker.ts` now applies schema migrations with `PRAGMA user_version`, authenticates agent-scoped actions with per-agent tokens, and holds a startup lock so concurrent launches do not step on each other.
+- `server.ts` is the Claude adapter. It exposes MCP tools, tracks surfaced-vs-seen receipts, keeps a local unread buffer, and turns inbound messages into Claude channel notifications.
+- `codex-server.ts` is the Codex adapter. It exposes the same broker tools with background inbox polling, thread history, and desktop notification fallback.
+- `google-server.ts` is the Gemini CLI and Antigravity adapter. It exposes the same broker tools with background inbox polling, thread history, and desktop notification fallback.
 - `cli.ts` is a local utility for inspecting agents and sending messages.
 - `examples/http-agent.ts` shows how a non-Claude agent can join the network.
+- `shared/agent-format.ts` renders consistent agent listings with inbox counts and metadata.
+- `shared/agent-metadata.ts` standardizes launcher, notification style, runtime, and workspace metadata.
+- `shared/desktop-notify.ts` provides best-effort local desktop notifications for polling-based clients.
 - `shared/types.ts` defines the common wire protocol.
 - `shared/config.ts` centralizes config with legacy env var fallbacks.
 - `shared/polling-adapter.ts` factors the shared logic for non-Claude polling-based clients.
@@ -296,8 +348,9 @@ bun cli.ts kill-broker
 | Environment variable | Default | Description |
 | --- | --- | --- |
 | `CLAUDY_TALKY_PORT` | `7899` | Broker port |
-| `CLAUDY_TALKY_DB` | Windows: `%LOCALAPPDATA%\\claudy-talky\\claudy-talky.db`; elsewhere: `~/.claudy-talky/claudy-talky.db` | SQLite database path |
+| `CLAUDY_TALKY_DB` | Windows: `%LOCALAPPDATA%\\claudy-talky\\claudy-talky.db`; elsewhere: `~/.claudy-talky/claudy-talky.db` | Preferred SQLite database path. If it cannot be opened, the broker falls back to `.claudy-talky.db` in the current working directory, then to a temp directory. |
 | `CLAUDY_TALKY_STALE_AGENT_MS` | `45000` | How long HTTP-only agents can miss heartbeats before cleanup |
+| `CLAUDY_TALKY_DESKTOP_NOTIFICATIONS` | `true` | Set to `0`, `false`, or `off` to disable desktop notification fallback for polling-based clients |
 | `OPENAI_API_KEY` | — | Enables Claude auto-summary generation |
 
 Legacy `CLAUDE_PEERS_PORT` and `CLAUDE_PEERS_DB` env vars are still accepted as fallbacks.
@@ -305,6 +358,11 @@ Legacy `CLAUDE_PEERS_PORT` and `CLAUDE_PEERS_DB` env vars are still accepted as 
 ## Notes
 
 - The broker binds to `127.0.0.1` only.
+- `send_message` now returns a message ID plus initial delivery state, and agents expose unread counts through `list_agents`.
+- Messages now carry `conversation_id`, optional `reply_to_message_id`, and three receipt timestamps: `delivered_at`, `surfaced_at`, and `seen_at`.
+- `message_history` lets adapters revisit recent threads even after background delivery has already surfaced the message.
+- `status` in `cli.ts` now reports the schema version, active DB path, whether a DB fallback was used, and unread queue totals.
 - Claude sessions receive messages instantly through channel notifications.
-- Codex, Gemini CLI, Antigravity, and other non-Claude agents use heartbeat plus background inbox polling. When their clients support standard MCP log notifications, incoming messages can surface automatically; `check_messages` remains the fallback inbox.
+- Codex, Gemini CLI, Antigravity, and other non-Claude agents use heartbeat plus background inbox polling. When their clients support standard MCP log notifications, incoming messages can surface automatically; desktop notifications act as a best-effort fallback, `check_messages` marks surfaced messages as seen, and `message_history` can reopen older threads.
+- Agent-scoped broker calls such as `heartbeat`, `send-message`, `poll-messages`, `acknowledge-messages`, `set-summary`, and `unregister` now require the auth token returned by `register-agent`.
 - This repo does not try to standardize every agent runtime yet; it provides a common local message bus Claude can already use today.

--- a/broker.db-fallback.test.ts
+++ b/broker.db-fallback.test.ts
@@ -1,0 +1,92 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+const port = 19000 + Math.floor(Math.random() * 1000);
+const brokerUrl = `http://127.0.0.1:${port}`;
+const repoRoot = process.cwd();
+const fixtureDir = join(process.cwd(), `.broker-fallback-${port}`);
+const badDbPath = join(fixtureDir, "not-a-db");
+const fallbackDbPath = join(fixtureDir, ".claudy-talky.db");
+
+let brokerProcess: ReturnType<typeof Bun.spawn>;
+
+async function waitForBroker() {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    try {
+      const response = await fetch(`${brokerUrl}/health`, {
+        signal: AbortSignal.timeout(250),
+      });
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      // Keep waiting for the broker to boot.
+    }
+
+    await Bun.sleep(100);
+  }
+
+  throw new Error("Timed out waiting for broker to start");
+}
+
+async function brokerFetch<T>(path: string, body?: unknown): Promise<T> {
+  const response = await fetch(`${brokerUrl}${path}`, {
+    method: body ? "POST" : "GET",
+    headers: body ? { "Content-Type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+    signal: AbortSignal.timeout(2000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`${response.status}: ${await response.text()}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+beforeAll(async () => {
+  mkdirSync(fixtureDir, { recursive: true });
+  mkdirSync(badDbPath, { recursive: true });
+
+  brokerProcess = Bun.spawn(["bun", join(repoRoot, "broker.ts")], {
+    cwd: fixtureDir,
+    stdout: "ignore",
+    stderr: "ignore",
+    env: {
+      ...process.env,
+      CLAUDY_TALKY_PORT: String(port),
+      CLAUDY_TALKY_DB: badDbPath,
+      CLAUDY_TALKY_STALE_AGENT_MS: "10000",
+    },
+  });
+
+  await waitForBroker();
+});
+
+afterAll(async () => {
+  try {
+    await brokerFetch("/shutdown", {});
+  } catch {
+    // Best effort.
+  }
+
+  await brokerProcess.exited;
+
+  rmSync(fixtureDir, { recursive: true, force: true });
+});
+
+test("falls back to a workspace database when the configured db path cannot be opened", async () => {
+  const health = await brokerFetch<{
+    status: string;
+    db_path: string;
+    primary_db_path: string;
+    db_fallback: boolean;
+  }>("/health");
+
+  expect(health.status).toBe("ok");
+  expect(health.primary_db_path).toBe(badDbPath);
+  expect(health.db_fallback).toBe(true);
+  expect(health.db_path).toBe(fallbackDbPath);
+  expect(existsSync(fallbackDbPath)).toBe(true);
+});

--- a/broker.start-lock.test.ts
+++ b/broker.start-lock.test.ts
@@ -1,0 +1,118 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { getBrokerLockPath } from "./shared/config.ts";
+
+const port = 20000 + Math.floor(Math.random() * 1000);
+const dbPath = join(process.cwd(), `.broker-lock-${port}.sqlite`);
+const brokerUrl = `http://127.0.0.1:${port}`;
+const lockPath = getBrokerLockPath(port);
+
+let primaryBroker: ReturnType<typeof Bun.spawn>;
+
+async function waitForBroker() {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    try {
+      const response = await fetch(`${brokerUrl}/health`, {
+        signal: AbortSignal.timeout(250),
+      });
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      // Keep waiting for the broker to boot.
+    }
+
+    await Bun.sleep(100);
+  }
+
+  throw new Error("Timed out waiting for broker to start");
+}
+
+async function brokerFetch<T>(path: string, body?: unknown): Promise<T> {
+  const response = await fetch(`${brokerUrl}${path}`, {
+    method: body ? "POST" : "GET",
+    headers: body ? { "Content-Type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+    signal: AbortSignal.timeout(2000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`${response.status}: ${await response.text()}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+beforeAll(async () => {
+  primaryBroker = Bun.spawn(["bun", "broker.ts"], {
+    cwd: process.cwd(),
+    stdout: "ignore",
+    stderr: "ignore",
+    env: {
+      ...process.env,
+      CLAUDY_TALKY_PORT: String(port),
+      CLAUDY_TALKY_DB: dbPath,
+      CLAUDY_TALKY_STALE_AGENT_MS: "10000",
+    },
+  });
+
+  await waitForBroker();
+});
+
+afterAll(async () => {
+  try {
+    await brokerFetch("/shutdown", {});
+  } catch {
+    // Best effort.
+  }
+
+  await primaryBroker.exited;
+
+  for (const suffix of ["", "-shm", "-wal"]) {
+    const path = `${dbPath}${suffix}`;
+    if (existsSync(path)) {
+      rmSync(path, { force: true });
+    }
+  }
+
+  rmSync(lockPath, { force: true });
+});
+
+test("exits quickly when another broker already owns the startup lock", async () => {
+  const competingBroker = Bun.spawn(["bun", "broker.ts"], {
+    cwd: process.cwd(),
+    stdout: "ignore",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      CLAUDY_TALKY_PORT: String(port),
+      CLAUDY_TALKY_DB: dbPath,
+      CLAUDY_TALKY_STALE_AGENT_MS: "10000",
+    },
+  });
+
+  const exitCode = await Promise.race([
+    competingBroker.exited,
+    Bun.sleep(3000).then(() => {
+      throw new Error("Competing broker did not exit");
+    }),
+  ]);
+
+  const stderr = await new Response(competingBroker.stderr).text();
+
+  expect(exitCode).not.toBe(0);
+  expect(stderr).toContain("startup lock");
+  expect(existsSync(lockPath)).toBe(true);
+
+  const health = await brokerFetch<{
+    status: string;
+    schema_version: number;
+  }>("/health");
+
+  expect(health.status).toBe("ok");
+  expect(health.schema_version).toBe(4);
+
+  const lockContents = readFileSync(lockPath, "utf8");
+  expect(lockContents).toContain(`"port":${port}`);
+});

--- a/broker.test.ts
+++ b/broker.test.ts
@@ -75,35 +75,47 @@ afterAll(async () => {
   }
 });
 
-test("registers agents, supports legacy listing, and delivers messages", async () => {
-  const claude = await brokerFetch<{ id: string }>("/register-agent", {
+test("registers agents, tracks threaded history, and separates surfaced from seen receipts", async () => {
+  const claude = await brokerFetch<{ id: string; auth_token?: string }>(
+    "/register-agent",
+    {
     name: "Claude Code @ app",
     kind: "claude-code",
     transport: "mcp-channel",
     cwd: "C:/repo/app",
     git_root: "C:/repo",
-    capabilities: ["messaging", "channel_notifications"],
+    capabilities: ["messaging", "channel_notifications", "message_receipts"],
     summary: "Working on the main app.",
-  });
+    }
+  );
 
-  const custom = await brokerFetch<{ id: string }>("/register-agent", {
+  const custom = await brokerFetch<{ id: string; auth_token?: string }>(
+    "/register-agent",
+    {
     name: "Echo Bot",
     kind: "custom-http-agent",
     transport: "http-poll",
-    capabilities: ["messaging", "polling"],
+    capabilities: ["messaging", "polling", "unread_counts"],
     summary: "Replies to every message.",
-  });
+    }
+  );
 
-  const agents = await brokerFetch<
-    Array<{ id: string; name: string; kind: string; capabilities: string[] }>
+  expect(typeof claude.auth_token).toBe("string");
+  expect(typeof custom.auth_token).toBe("string");
+
+  const initialAgents = await brokerFetch<
+    Array<{
+      id: string;
+      unread_count: number;
+      undelivered_count: number;
+      delivered_unseen_count: number;
+    }>
   >("/list-agents", {
     scope: "machine",
   });
 
-  expect(agents).toHaveLength(2);
-  expect(agents.map((agent) => agent.id).sort()).toEqual(
-    [claude.id, custom.id].sort()
-  );
+  expect(initialAgents).toHaveLength(2);
+  expect(initialAgents.every((agent) => agent.unread_count === 0)).toBe(true);
 
   const legacyPeers = await brokerFetch<
     Array<{ id: string; name: string; kind: string }>
@@ -125,20 +137,292 @@ test("registers agents, supports legacy listing, and delivers messages", async (
   expect(filteredAgents).toHaveLength(1);
   expect(filteredAgents[0]?.id).toBe(custom.id);
 
-  await brokerFetch<{ ok: boolean }>("/send-message", {
+  const sent = await brokerFetch<{
+    ok: boolean;
+    message?: {
+      id: number;
+      from_id: string;
+      to_id: string;
+      conversation_id: string;
+      reply_to_message_id: number | null;
+      delivered: boolean;
+      delivered_at: string | null;
+      surfaced_at: string | null;
+      seen_at: string | null;
+    };
+  }>("/send-message", {
     from_id: claude.id,
     to_id: custom.id,
     text: "Can you confirm receipt?",
+    auth_token: claude.auth_token,
   });
 
+  expect(sent.ok).toBe(true);
+  expect(sent.message?.from_id).toBe(claude.id);
+  expect(sent.message?.to_id).toBe(custom.id);
+  expect(sent.message?.conversation_id).toMatch(/^conv-/);
+  expect(sent.message?.reply_to_message_id).toBeNull();
+  expect(sent.message?.delivered).toBe(false);
+  expect(sent.message?.delivered_at).toBeNull();
+  expect(sent.message?.surfaced_at).toBeNull();
+  expect(sent.message?.seen_at).toBeNull();
+
+  const queuedAgents = await brokerFetch<
+    Array<{
+      id: string;
+      unread_count: number;
+      undelivered_count: number;
+      delivered_unseen_count: number;
+      surfaced_unseen_count: number;
+    }>
+  >("/list-agents", {
+    scope: "machine",
+  });
+
+  const queuedCustom = queuedAgents.find((agent) => agent.id === custom.id);
+  expect(queuedCustom?.unread_count).toBe(1);
+  expect(queuedCustom?.undelivered_count).toBe(1);
+  expect(queuedCustom?.delivered_unseen_count).toBe(0);
+  expect(queuedCustom?.surfaced_unseen_count).toBe(0);
+
   const polled = await brokerFetch<{
-    messages: Array<{ from_id: string; to_id: string; text: string }>;
+    messages: Array<{
+      id: number;
+      from_id: string;
+      to_id: string;
+      text: string;
+      conversation_id: string;
+      reply_to_message_id: number | null;
+      delivered: boolean;
+      delivered_at: string | null;
+      surfaced_at: string | null;
+      seen_at: string | null;
+    }>;
   }>("/poll-messages", {
     id: custom.id,
+    auth_token: custom.auth_token,
   });
 
   expect(polled.messages).toHaveLength(1);
+  expect(polled.messages[0]?.id).toBe(sent.message?.id);
   expect(polled.messages[0]?.from_id).toBe(claude.id);
   expect(polled.messages[0]?.to_id).toBe(custom.id);
   expect(polled.messages[0]?.text).toBe("Can you confirm receipt?");
+  expect(polled.messages[0]?.conversation_id).toBe(sent.message?.conversation_id);
+  expect(polled.messages[0]?.reply_to_message_id).toBeNull();
+  expect(polled.messages[0]?.delivered).toBe(true);
+  expect(polled.messages[0]?.delivered_at).not.toBeNull();
+  expect(polled.messages[0]?.surfaced_at).toBeNull();
+  expect(polled.messages[0]?.seen_at).toBeNull();
+
+  const deliveredAgents = await brokerFetch<
+    Array<{
+      id: string;
+      unread_count: number;
+      undelivered_count: number;
+      delivered_unseen_count: number;
+      surfaced_unseen_count: number;
+    }>
+  >("/list-agents", {
+    scope: "machine",
+  });
+
+  const deliveredCustom = deliveredAgents.find((agent) => agent.id === custom.id);
+  expect(deliveredCustom?.unread_count).toBe(1);
+  expect(deliveredCustom?.undelivered_count).toBe(0);
+  expect(deliveredCustom?.delivered_unseen_count).toBe(1);
+  expect(deliveredCustom?.surfaced_unseen_count).toBe(0);
+
+  const surfaced = await brokerFetch<{ ok: boolean; updated: number }>(
+    "/mark-messages-surfaced",
+    {
+      id: custom.id,
+      message_ids: [sent.message?.id],
+      auth_token: custom.auth_token,
+    }
+  );
+
+  expect(surfaced.ok).toBe(true);
+  expect(surfaced.updated).toBe(1);
+
+  const surfacedAgents = await brokerFetch<
+    Array<{
+      id: string;
+      unread_count: number;
+      undelivered_count: number;
+      delivered_unseen_count: number;
+      surfaced_unseen_count: number;
+    }>
+  >("/list-agents", {
+    scope: "machine",
+  });
+
+  const surfacedCustom = surfacedAgents.find((agent) => agent.id === custom.id);
+  expect(surfacedCustom?.unread_count).toBe(1);
+  expect(surfacedCustom?.delivered_unseen_count).toBe(1);
+  expect(surfacedCustom?.surfaced_unseen_count).toBe(1);
+
+  const acknowledged = await brokerFetch<{ ok: boolean; updated: number }>(
+    "/acknowledge-messages",
+    {
+      id: custom.id,
+      message_ids: [sent.message?.id],
+      auth_token: custom.auth_token,
+    }
+  );
+
+  expect(acknowledged.ok).toBe(true);
+  expect(acknowledged.updated).toBe(1);
+
+  const clearedAgents = await brokerFetch<
+    Array<{
+      id: string;
+      unread_count: number;
+      undelivered_count: number;
+      delivered_unseen_count: number;
+      surfaced_unseen_count: number;
+    }>
+  >("/list-agents", {
+    scope: "machine",
+  });
+
+  const clearedCustom = clearedAgents.find((agent) => agent.id === custom.id);
+  expect(clearedCustom?.unread_count).toBe(0);
+  expect(clearedCustom?.undelivered_count).toBe(0);
+  expect(clearedCustom?.delivered_unseen_count).toBe(0);
+  expect(clearedCustom?.surfaced_unseen_count).toBe(0);
+
+  const reply = await brokerFetch<{
+    ok: boolean;
+    message?: {
+      id: number;
+      conversation_id: string;
+      reply_to_message_id: number | null;
+      delivered: boolean;
+    };
+  }>("/send-message", {
+    from_id: custom.id,
+    to_id: claude.id,
+    text: "Confirmed. Threading looks good on my side.",
+    reply_to_message_id: sent.message?.id,
+    auth_token: custom.auth_token,
+  });
+
+  expect(reply.ok).toBe(true);
+  expect(reply.message?.conversation_id).toBe(sent.message?.conversation_id);
+  expect(reply.message?.reply_to_message_id).toBe(sent.message?.id);
+  expect(reply.message?.delivered).toBe(false);
+
+  const history = await brokerFetch<{
+    messages: Array<{
+      id: number;
+      from_id: string;
+      to_id: string;
+      conversation_id: string;
+      reply_to_message_id: number | null;
+      text: string;
+    }>;
+  }>("/message-history", {
+    agent_id: claude.id,
+    with_agent_id: custom.id,
+    auth_token: claude.auth_token,
+  });
+
+  expect(history.messages).toHaveLength(2);
+  expect(history.messages[0]?.id).toBe(sent.message?.id);
+  expect(history.messages[0]?.conversation_id).toBe(sent.message?.conversation_id);
+  expect(history.messages[1]?.id).toBe(reply.message?.id);
+  expect(history.messages[1]?.conversation_id).toBe(sent.message?.conversation_id);
+  expect(history.messages[1]?.reply_to_message_id).toBe(sent.message?.id);
+  expect(history.messages[1]?.text).toContain("Threading looks good");
+
+  const claudePoll = await brokerFetch<{
+    messages: Array<{
+      id: number;
+      conversation_id: string;
+      reply_to_message_id: number | null;
+    }>;
+  }>("/poll-messages", {
+    id: claude.id,
+    auth_token: claude.auth_token,
+  });
+
+  expect(claudePoll.messages).toHaveLength(1);
+  expect(claudePoll.messages[0]?.id).toBe(reply.message?.id);
+  expect(claudePoll.messages[0]?.conversation_id).toBe(sent.message?.conversation_id);
+  expect(claudePoll.messages[0]?.reply_to_message_id).toBe(sent.message?.id);
+
+  const claudeSurfaced = await brokerFetch<{ ok: boolean; updated: number }>(
+    "/mark-messages-surfaced",
+    {
+      id: claude.id,
+      message_ids: [reply.message?.id],
+      auth_token: claude.auth_token,
+    }
+  );
+
+  expect(claudeSurfaced.ok).toBe(true);
+  expect(claudeSurfaced.updated).toBe(1);
+
+  const claudeAcknowledged = await brokerFetch<{ ok: boolean; updated: number }>(
+    "/acknowledge-messages",
+    {
+      id: claude.id,
+      message_ids: [reply.message?.id],
+      auth_token: claude.auth_token,
+    }
+  );
+
+  expect(claudeAcknowledged.ok).toBe(true);
+  expect(claudeAcknowledged.updated).toBe(1);
+
+  const health = await brokerFetch<{
+    status: string;
+    unread_messages: number;
+    undelivered_messages: number;
+    surfaced_unseen_messages: number;
+    schema_version: number;
+  }>("/health");
+
+  expect(health.status).toBe("ok");
+  expect(health.unread_messages).toBe(0);
+  expect(health.undelivered_messages).toBe(0);
+  expect(health.surfaced_unseen_messages).toBe(0);
+  expect(health.schema_version).toBe(4);
+});
+
+test("rejects spoofed agent actions without the correct auth token", async () => {
+  const sender = await brokerFetch<{ id: string; auth_token?: string }>(
+    "/register-agent",
+    {
+      name: "Secure Sender",
+      kind: "custom-http-agent",
+      transport: "http-poll",
+    }
+  );
+
+  const target = await brokerFetch<{ id: string; auth_token?: string }>(
+    "/register-agent",
+    {
+      name: "Secure Target",
+      kind: "custom-http-agent",
+      transport: "http-poll",
+    }
+  );
+
+  const response = await fetch(`${brokerUrl}/send-message`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      from_id: sender.id,
+      to_id: target.id,
+      text: "This should fail",
+      auth_token: "definitely-wrong",
+    }),
+    signal: AbortSignal.timeout(2000),
+  });
+
+  expect(response.status).toBe(403);
+  const payload = (await response.json()) as { error?: string };
+  expect(payload.error).toContain("invalid auth token");
 });

--- a/broker.ts
+++ b/broker.ts
@@ -12,25 +12,50 @@
  */
 
 import { Database } from "bun:sqlite";
-import { mkdirSync } from "node:fs";
+import {
+  mkdirSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname } from "node:path";
-import { getBrokerPort, getDbPath, getStaleAgentMs } from "./shared/config.ts";
+import {
+  getBrokerLockPath,
+  getBrokerPort,
+  getDbFallbackPaths,
+  getDbPath,
+  getStaleAgentMs,
+} from "./shared/config.ts";
 import type {
+  AcknowledgeMessagesRequest,
+  AcknowledgeMessagesResponse,
   Agent,
+  BrokerHealthResponse,
   HeartbeatRequest,
   ListAgentsRequest,
+  MarkMessagesSurfacedRequest,
+  MarkMessagesSurfacedResponse,
   Message,
+  MessageHistoryRequest,
+  MessageHistoryResponse,
   PollMessagesRequest,
   PollMessagesResponse,
   RegisterAgentRequest,
   RegisterAgentResponse,
   SendMessageRequest,
+  SendMessageResponse,
   SetSummaryRequest,
+  UnregisterRequest,
 } from "./shared/types.ts";
 
 const PORT = getBrokerPort();
-const DB_PATH = getDbPath();
+const PRIMARY_DB_PATH = getDbPath();
+const LOCK_PATH = getBrokerLockPath(PORT);
 const STALE_AGENT_MS = getStaleAgentMs();
+const LATEST_SCHEMA_VERSION = 4;
+const DEFAULT_HISTORY_LIMIT = 20;
+const MAX_HISTORY_LIMIT = 100;
 
 type AgentRow = {
   id: string;
@@ -44,9 +69,53 @@ type AgentRow = {
   summary: string;
   capabilities: string;
   metadata: string;
+  auth_token: string;
   registered_at: string;
   last_seen: string;
 };
+
+type AgentAuthRow = {
+  id: string;
+  auth_token: string;
+};
+
+type MessageRow = {
+  id: number;
+  from_id: string;
+  to_id: string;
+  text: string;
+  sent_at: string;
+  conversation_id: string;
+  reply_to_message_id: number | null;
+  delivered: number;
+  delivered_at: string | null;
+  surfaced_at: string | null;
+  seen_at: string | null;
+};
+
+type AgentCountRow = {
+  agent_id: string;
+  unread_count: number | bigint | null;
+  undelivered_count: number | bigint | null;
+  delivered_unseen_count: number | bigint | null;
+  surfaced_unseen_count: number | bigint | null;
+};
+
+type MessageTotalsRow = {
+  unread_messages: number | bigint | null;
+  undelivered_messages: number | bigint | null;
+  surfaced_unseen_messages: number | bigint | null;
+};
+
+class BrokerRequestError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "BrokerRequestError";
+    this.status = status;
+  }
+}
 
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",
@@ -54,45 +123,336 @@ const CORS_HEADERS = {
   "Access-Control-Allow-Headers": "Content-Type",
 };
 
-// --- Database setup ---
+function log(message: string) {
+  console.error(`[claudy-talky broker] ${message}`);
+}
 
-mkdirSync(dirname(DB_PATH), { recursive: true });
-const db = new Database(DB_PATH);
+function normalizeCount(value: unknown): number {
+  const count = typeof value === "bigint" ? Number(value) : Number(value ?? 0);
+  return Number.isFinite(count) ? count : 0;
+}
+
+function isPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readLockOwnerPid(lockPath: string): number | null {
+  try {
+    const raw = readFileSync(lockPath, "utf8").trim();
+    if (!raw) {
+      return null;
+    }
+
+    const payload = JSON.parse(raw) as { pid?: unknown };
+    const pid = Number(payload.pid);
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+function acquireStartupLock(lockPath: string): { release: () => void } {
+  mkdirSync(dirname(lockPath), { recursive: true });
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const fd = openSync(lockPath, "wx");
+      writeFileSync(
+        fd,
+        JSON.stringify({
+          pid: process.pid,
+          created_at: new Date().toISOString(),
+          port: PORT,
+        })
+      );
+
+      let released = false;
+      return {
+        release: () => {
+          if (released) {
+            return;
+          }
+
+          released = true;
+          try {
+            rmSync(lockPath, { force: true });
+          } catch {
+            // Best effort.
+          }
+        },
+      };
+    } catch (error) {
+      const code =
+        error && typeof error === "object" && "code" in error
+          ? String((error as { code?: unknown }).code)
+          : "";
+
+      if (code !== "EEXIST") {
+        throw error;
+      }
+
+      const ownerPid = readLockOwnerPid(lockPath);
+      if (ownerPid !== null && isPidAlive(ownerPid)) {
+        throw new Error(`broker startup lock is held by pid ${ownerPid}`);
+      }
+
+      try {
+        rmSync(lockPath, { force: true });
+      } catch {
+        // If removal fails, the next attempt will surface the real error.
+      }
+    }
+  }
+
+  throw new Error("broker startup lock could not be acquired");
+}
+
+const startupLock = acquireStartupLock(LOCK_PATH);
+let startupLockReleased = false;
+
+function releaseStartupLock() {
+  if (startupLockReleased) {
+    return;
+  }
+
+  startupLockReleased = true;
+  startupLock.release();
+}
+
+process.once("exit", releaseStartupLock);
+process.once("SIGINT", releaseStartupLock);
+process.once("SIGTERM", releaseStartupLock);
+
+function openDatabase() {
+  const candidates = getDbFallbackPaths();
+  let firstError: unknown = null;
+
+  for (const [index, dbPath] of candidates.entries()) {
+    try {
+      mkdirSync(dirname(dbPath), { recursive: true });
+      const database = new Database(dbPath);
+
+      if (index > 0) {
+        log(`using fallback database path ${dbPath} (primary: ${PRIMARY_DB_PATH})`);
+      }
+
+      return {
+        db: database,
+        dbPath,
+        dbFallback: index > 0,
+      };
+    } catch (error) {
+      firstError ??= error;
+      log(
+        `failed to open database at ${dbPath}: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  throw firstError instanceof Error
+    ? firstError
+    : new Error("Failed to open any claudy-talky database path");
+}
+
+const { db, dbPath: DB_PATH, dbFallback: DB_FALLBACK } = openDatabase();
+
 db.run("PRAGMA journal_mode = WAL");
 db.run("PRAGMA busy_timeout = 3000");
 
-db.run(`
-  CREATE TABLE IF NOT EXISTS agents (
-    id TEXT PRIMARY KEY,
-    pid INTEGER,
-    name TEXT NOT NULL,
-    kind TEXT NOT NULL,
-    transport TEXT NOT NULL,
-    cwd TEXT,
-    git_root TEXT,
-    tty TEXT,
-    summary TEXT NOT NULL DEFAULT '',
-    capabilities TEXT NOT NULL DEFAULT '[]',
-    metadata TEXT NOT NULL DEFAULT '{}',
-    registered_at TEXT NOT NULL,
-    last_seen TEXT NOT NULL
-  )
-`);
+function tableExists(name: string): boolean {
+  const row = db
+    .prepare(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1"
+    )
+    .get(name) as { name: string } | null;
+  return row !== null;
+}
 
-db.run(`
-  CREATE TABLE IF NOT EXISTS messages (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    from_id TEXT NOT NULL,
-    to_id TEXT NOT NULL,
-    text TEXT NOT NULL,
-    sent_at TEXT NOT NULL,
-    delivered INTEGER NOT NULL DEFAULT 0,
-    FOREIGN KEY (from_id) REFERENCES agents(id),
-    FOREIGN KEY (to_id) REFERENCES agents(id)
-  )
-`);
+function columnExists(table: string, column: string): boolean {
+  const rows = db
+    .prepare(`PRAGMA table_info(${table})`)
+    .all() as Array<{ name: string }>;
+  return rows.some((row) => row.name === column);
+}
 
-// --- Helpers ---
+function runMigration(version: number, name: string, migrate: () => void) {
+  log(`applying schema migration ${version}: ${name}`);
+  db.run("BEGIN IMMEDIATE");
+
+  try {
+    migrate();
+    db.run(`PRAGMA user_version = ${version}`);
+    db.run("COMMIT");
+  } catch (error) {
+    db.run("ROLLBACK");
+    throw error;
+  }
+}
+
+function getSchemaVersion(): number {
+  const row = db.prepare("PRAGMA user_version").get() as
+    | { user_version?: number | bigint }
+    | undefined;
+  return normalizeCount(row?.user_version);
+}
+
+function generateAuthToken(): string {
+  return crypto.randomUUID().replaceAll("-", "");
+}
+
+function generateConversationId(): string {
+  return `conv-${crypto.randomUUID().replaceAll("-", "")}`;
+}
+
+function backfillMissingAgentAuthTokens() {
+  if (!tableExists("agents") || !columnExists("agents", "auth_token")) {
+    return;
+  }
+
+  const rows = db
+    .prepare("SELECT id FROM agents WHERE auth_token IS NULL OR auth_token = ''")
+    .all() as Array<{ id: string }>;
+
+  const update = db.prepare("UPDATE agents SET auth_token = ? WHERE id = ?");
+  for (const row of rows) {
+    update.run(generateAuthToken(), row.id);
+  }
+}
+
+function applyMigrations() {
+  let version = getSchemaVersion();
+
+  if (version < 1) {
+    runMigration(1, "create base tables", () => {
+      db.run(`
+        CREATE TABLE IF NOT EXISTS agents (
+          id TEXT PRIMARY KEY,
+          pid INTEGER,
+          name TEXT NOT NULL,
+          kind TEXT NOT NULL,
+          transport TEXT NOT NULL,
+          cwd TEXT,
+          git_root TEXT,
+          tty TEXT,
+          summary TEXT NOT NULL DEFAULT '',
+          capabilities TEXT NOT NULL DEFAULT '[]',
+          metadata TEXT NOT NULL DEFAULT '{}',
+          registered_at TEXT NOT NULL,
+          last_seen TEXT NOT NULL
+        )
+      `);
+
+      db.run(`
+        CREATE TABLE IF NOT EXISTS messages (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          from_id TEXT NOT NULL,
+          to_id TEXT NOT NULL,
+          text TEXT NOT NULL,
+          sent_at TEXT NOT NULL,
+          delivered INTEGER NOT NULL DEFAULT 0,
+          FOREIGN KEY (from_id) REFERENCES agents(id),
+          FOREIGN KEY (to_id) REFERENCES agents(id)
+        )
+      `);
+    });
+
+    version = 1;
+  }
+
+  if (version < 2) {
+    runMigration(2, "add message delivery timestamps", () => {
+      if (!columnExists("messages", "delivered_at")) {
+        db.run("ALTER TABLE messages ADD COLUMN delivered_at TEXT");
+      }
+
+      if (!columnExists("messages", "seen_at")) {
+        db.run("ALTER TABLE messages ADD COLUMN seen_at TEXT");
+      }
+
+      db.run(`
+        UPDATE messages
+        SET delivered_at = COALESCE(delivered_at, sent_at)
+        WHERE delivered = 1 AND delivered_at IS NULL
+      `);
+    });
+
+    version = 2;
+  }
+
+  if (version < 3) {
+    runMigration(3, "add agent auth tokens", () => {
+      if (!columnExists("agents", "auth_token")) {
+        db.run("ALTER TABLE agents ADD COLUMN auth_token TEXT NOT NULL DEFAULT ''");
+      }
+
+      backfillMissingAgentAuthTokens();
+    });
+
+    version = 3;
+  }
+
+  if (version < 4) {
+    runMigration(4, "add conversation metadata and surfaced receipts", () => {
+      if (!columnExists("messages", "conversation_id")) {
+        db.run("ALTER TABLE messages ADD COLUMN conversation_id TEXT");
+      }
+
+      if (!columnExists("messages", "reply_to_message_id")) {
+        db.run("ALTER TABLE messages ADD COLUMN reply_to_message_id INTEGER");
+      }
+
+      if (!columnExists("messages", "surfaced_at")) {
+        db.run("ALTER TABLE messages ADD COLUMN surfaced_at TEXT");
+      }
+
+      db.run(`
+        UPDATE messages
+        SET conversation_id = COALESCE(NULLIF(conversation_id, ''), 'legacy-' || id)
+        WHERE conversation_id IS NULL OR conversation_id = ''
+      `);
+
+      db.run(`
+        UPDATE messages
+        SET surfaced_at = COALESCE(surfaced_at, seen_at)
+        WHERE seen_at IS NOT NULL AND surfaced_at IS NULL
+      `);
+
+      db.run(`
+        CREATE INDEX IF NOT EXISTS idx_messages_recipient_delivery
+        ON messages (to_id, delivered, sent_at, id)
+      `);
+
+      db.run(`
+        CREATE INDEX IF NOT EXISTS idx_messages_conversation
+        ON messages (conversation_id, sent_at, id)
+      `);
+
+      db.run(`
+        CREATE INDEX IF NOT EXISTS idx_messages_history
+        ON messages (from_id, to_id, sent_at, id)
+      `);
+    });
+
+    version = 4;
+  }
+
+  if (version !== LATEST_SCHEMA_VERSION) {
+    throw new Error(
+      `Unexpected schema version after migration: ${version} (expected ${LATEST_SCHEMA_VERSION})`
+    );
+  }
+}
+
+applyMigrations();
 
 function normalizeText(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
@@ -139,6 +499,41 @@ function normalizeMetadata(value: unknown): Record<string, unknown> {
   );
 }
 
+function normalizeMessageIds(value: unknown): number[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const seen = new Set<number>();
+  const ids: number[] = [];
+
+  for (const item of value) {
+    const id = typeof item === "number" ? item : Number(item);
+    if (!Number.isInteger(id) || id <= 0 || seen.has(id)) {
+      continue;
+    }
+
+    seen.add(id);
+    ids.push(id);
+  }
+
+  return ids;
+}
+
+function normalizeReplyToMessageId(value: unknown): number | null {
+  const id = typeof value === "number" ? value : Number(value);
+  return Number.isInteger(id) && id > 0 ? id : null;
+}
+
+function normalizeHistoryLimit(value: unknown): number {
+  const limit = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(limit) || limit <= 0) {
+    return DEFAULT_HISTORY_LIMIT;
+  }
+
+  return Math.min(limit, MAX_HISTORY_LIMIT);
+}
+
 function parseJsonArray(value: string): string[] {
   try {
     return normalizeCapabilities(JSON.parse(value));
@@ -155,15 +550,46 @@ function parseJsonObject(value: string): Record<string, unknown> {
   }
 }
 
-function toAgent(row: AgentRow): Agent {
+function getAgentCountsMap(): Map<string, AgentCountRow> {
+  const rows = selectMessageCountsByAgent.all() as AgentCountRow[];
+  return new Map(rows.map((row) => [row.agent_id, row]));
+}
+
+function toAgent(row: AgentRow, counts?: AgentCountRow): Agent {
   return {
-    ...row,
+    id: row.id,
     pid: row.pid ?? null,
+    name: row.name,
+    kind: row.kind,
+    transport: row.transport,
     cwd: row.cwd ?? null,
     git_root: row.git_root ?? null,
     tty: row.tty ?? null,
+    summary: row.summary,
     capabilities: parseJsonArray(row.capabilities),
     metadata: parseJsonObject(row.metadata),
+    unread_count: normalizeCount(counts?.unread_count),
+    undelivered_count: normalizeCount(counts?.undelivered_count),
+    delivered_unseen_count: normalizeCount(counts?.delivered_unseen_count),
+    surfaced_unseen_count: normalizeCount(counts?.surfaced_unseen_count),
+    registered_at: row.registered_at,
+    last_seen: row.last_seen,
+  };
+}
+
+function toMessage(row: MessageRow): Message {
+  return {
+    id: row.id,
+    from_id: row.from_id,
+    to_id: row.to_id,
+    text: row.text,
+    sent_at: row.sent_at,
+    conversation_id: row.conversation_id,
+    reply_to_message_id: row.reply_to_message_id ?? null,
+    delivered: row.delivered === 1,
+    delivered_at: row.delivered_at ?? null,
+    surfaced_at: row.surfaced_at ?? null,
+    seen_at: row.seen_at ?? null,
   };
 }
 
@@ -181,6 +607,24 @@ function deriveDefaultName(kind: string, cwd: string | null): string {
 function removeAgent(id: string) {
   deleteAgent.run(id);
   deleteMessagesForAgent.run(id, id);
+}
+
+function requireAgentAuth(id: string, authToken: unknown): AgentAuthRow {
+  const agent = selectAgentAuthById.get(id) as AgentAuthRow | null;
+  if (!agent) {
+    throw new BrokerRequestError(404, `Agent ${id} not found`);
+  }
+
+  const token = normalizeText(authToken);
+  if (!token) {
+    throw new BrokerRequestError(401, `Agent ${id} is missing an auth token`);
+  }
+
+  if (agent.auth_token !== token) {
+    throw new BrokerRequestError(403, `Agent ${id} supplied an invalid auth token`);
+  }
+
+  return agent;
 }
 
 function isAgentAlive(agent: Agent): boolean {
@@ -203,14 +647,12 @@ function isAgentAlive(agent: Agent): boolean {
   return false;
 }
 
-// --- Prepared statements ---
-
 const insertAgent = db.prepare(`
   INSERT INTO agents (
     id, pid, name, kind, transport, cwd, git_root, tty, summary,
-    capabilities, metadata, registered_at, last_seen
+    capabilities, metadata, auth_token, registered_at, last_seen
   )
-  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `);
 
 const updateLastSeen = db.prepare(`
@@ -245,24 +687,68 @@ const selectAgentRowById = db.prepare(`
   SELECT * FROM agents WHERE id = ?
 `);
 
+const selectAgentAuthById = db.prepare(`
+  SELECT id, auth_token FROM agents WHERE id = ?
+`);
+
 const selectAgentIdByPid = db.prepare(`
   SELECT id FROM agents WHERE pid = ?
 `);
 
+const selectMessageRowById = db.prepare(`
+  SELECT * FROM messages WHERE id = ?
+`);
+
 const insertMessage = db.prepare(`
-  INSERT INTO messages (from_id, to_id, text, sent_at, delivered)
-  VALUES (?, ?, ?, ?, 0)
+  INSERT INTO messages (
+    from_id, to_id, text, sent_at, conversation_id, reply_to_message_id,
+    delivered, delivered_at, surfaced_at, seen_at
+  )
+  VALUES (?, ?, ?, ?, ?, ?, 0, NULL, NULL, NULL)
 `);
 
 const selectUndelivered = db.prepare(`
-  SELECT * FROM messages WHERE to_id = ? AND delivered = 0 ORDER BY sent_at ASC
+  SELECT * FROM messages WHERE to_id = ? AND delivered = 0 ORDER BY sent_at ASC, id ASC
 `);
 
 const markDelivered = db.prepare(`
-  UPDATE messages SET delivered = 1 WHERE id = ?
+  UPDATE messages
+  SET delivered = 1, delivered_at = COALESCE(delivered_at, ?)
+  WHERE id = ?
 `);
 
-// --- Generate agent ID ---
+const markSurfaced = db.prepare(`
+  UPDATE messages
+  SET surfaced_at = COALESCE(surfaced_at, ?)
+  WHERE id = ? AND to_id = ?
+`);
+
+const markSeen = db.prepare(`
+  UPDATE messages
+  SET
+    surfaced_at = COALESCE(surfaced_at, ?),
+    seen_at = COALESCE(seen_at, ?)
+  WHERE id = ? AND to_id = ?
+`);
+
+const selectMessageCountsByAgent = db.prepare(`
+  SELECT
+    to_id AS agent_id,
+    COALESCE(SUM(CASE WHEN seen_at IS NULL THEN 1 ELSE 0 END), 0) AS unread_count,
+    COALESCE(SUM(CASE WHEN delivered = 0 THEN 1 ELSE 0 END), 0) AS undelivered_count,
+    COALESCE(SUM(CASE WHEN delivered = 1 AND seen_at IS NULL THEN 1 ELSE 0 END), 0) AS delivered_unseen_count,
+    COALESCE(SUM(CASE WHEN surfaced_at IS NOT NULL AND seen_at IS NULL THEN 1 ELSE 0 END), 0) AS surfaced_unseen_count
+  FROM messages
+  GROUP BY to_id
+`);
+
+const selectMessageTotals = db.prepare(`
+  SELECT
+    COALESCE(SUM(CASE WHEN seen_at IS NULL THEN 1 ELSE 0 END), 0) AS unread_messages,
+    COALESCE(SUM(CASE WHEN delivered = 0 THEN 1 ELSE 0 END), 0) AS undelivered_messages,
+    COALESCE(SUM(CASE WHEN surfaced_at IS NOT NULL AND seen_at IS NULL THEN 1 ELSE 0 END), 0) AS surfaced_unseen_messages
+  FROM messages
+`);
 
 function generateId(): string {
   const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
@@ -273,7 +759,6 @@ function generateId(): string {
   return id;
 }
 
-// Clean up stale agents on startup and periodically.
 function cleanStaleAgents() {
   const rows = selectAllAgentRows.all() as AgentRow[];
   for (const row of rows) {
@@ -283,8 +768,6 @@ function cleanStaleAgents() {
 
 cleanStaleAgents();
 setInterval(cleanStaleAgents, 30_000);
-
-// --- Request handlers ---
 
 function handleRegister(body: RegisterAgentRequest): RegisterAgentResponse {
   const now = new Date().toISOString();
@@ -299,6 +782,7 @@ function handleRegister(body: RegisterAgentRequest): RegisterAgentResponse {
   const metadata = normalizeMetadata(body.metadata);
   const name = normalizeText(body.name) || deriveDefaultName(kind, cwd);
   const id = generateId();
+  const authToken = generateAuthToken();
 
   if (pid !== null) {
     const existing = selectAgentIdByPid.get(pid) as { id: string } | null;
@@ -319,18 +803,21 @@ function handleRegister(body: RegisterAgentRequest): RegisterAgentResponse {
     summary,
     JSON.stringify(capabilities),
     JSON.stringify(metadata),
+    authToken,
     now,
     now
   );
 
-  return { id };
+  return { id, auth_token: authToken };
 }
 
 function handleHeartbeat(body: HeartbeatRequest): void {
+  requireAgentAuth(body.id, body.auth_token);
   updateLastSeen.run(new Date().toISOString(), body.id);
 }
 
 function handleSetSummary(body: SetSummaryRequest): void {
+  requireAgentAuth(body.id, body.auth_token);
   updateSummary.run(normalizeText(body.summary), body.id);
 }
 
@@ -356,7 +843,8 @@ function handleListAgents(body: ListAgentsRequest): Agent[] {
       break;
   }
 
-  let agents = rows.map(toAgent);
+  const counts = getAgentCountsMap();
+  let agents = rows.map((row) => toAgent(row, counts.get(row.id)));
 
   if (body.exclude_id) {
     agents = agents.filter((agent) => agent.id !== body.exclude_id);
@@ -381,34 +869,203 @@ function handleListAgents(body: ListAgentsRequest): Agent[] {
     );
 }
 
-function handleSendMessage(body: SendMessageRequest): { ok: boolean; error?: string } {
+function handleSendMessage(body: SendMessageRequest): SendMessageResponse {
+  requireAgentAuth(body.from_id, body.auth_token);
+
   const target = selectAgentRowById.get(body.to_id) as AgentRow | null;
   if (!target) {
     return { ok: false, error: `Agent ${body.to_id} not found` };
   }
 
-  insertMessage.run(
+  const text = normalizeText(body.text);
+  if (!text) {
+    return { ok: false, error: "Message text cannot be empty" };
+  }
+
+  const replyToMessageId = normalizeReplyToMessageId(body.reply_to_message_id);
+  let conversationId = normalizeText(body.conversation_id);
+
+  if (replyToMessageId !== null) {
+    const parent = selectMessageRowById.get(replyToMessageId) as MessageRow | null;
+    if (!parent) {
+      return { ok: false, error: `Reply target message ${replyToMessageId} not found` };
+    }
+
+    const participants = new Set([parent.from_id, parent.to_id]);
+    if (!participants.has(body.from_id) || !participants.has(body.to_id)) {
+      return {
+        ok: false,
+        error: "Reply participants must match the original conversation",
+      };
+    }
+
+    if (conversationId && conversationId !== parent.conversation_id) {
+      return {
+        ok: false,
+        error: "conversation_id does not match the reply target conversation",
+      };
+    }
+
+    conversationId = parent.conversation_id;
+  }
+
+  if (!conversationId) {
+    conversationId = generateConversationId();
+  }
+
+  const sentAt = new Date().toISOString();
+  const result = insertMessage.run(
     body.from_id,
     body.to_id,
-    normalizeText(body.text),
-    new Date().toISOString()
+    text,
+    sentAt,
+    conversationId,
+    replyToMessageId
   );
+  const id = normalizeCount(result.lastInsertRowid);
 
-  return { ok: true };
+  return {
+    ok: true,
+    message: {
+      id,
+      from_id: body.from_id,
+      to_id: body.to_id,
+      text,
+      sent_at: sentAt,
+      conversation_id: conversationId,
+      reply_to_message_id: replyToMessageId,
+      delivered: false,
+      delivered_at: null,
+      surfaced_at: null,
+      seen_at: null,
+    },
+  };
 }
 
 function handlePollMessages(body: PollMessagesRequest): PollMessagesResponse {
-  const messages = selectUndelivered.all(body.id) as Message[];
+  requireAgentAuth(body.id, body.auth_token);
 
-  for (const message of messages) {
-    markDelivered.run(message.id);
+  const rows = selectUndelivered.all(body.id) as MessageRow[];
+  if (rows.length === 0) {
+    return { messages: [] };
   }
+
+  const deliveredAt = new Date().toISOString();
+  const messages = rows.map((row) => {
+    markDelivered.run(deliveredAt, row.id);
+
+    return toMessage({
+      ...row,
+      delivered: 1,
+      delivered_at: row.delivered_at ?? deliveredAt,
+    });
+  });
 
   return { messages };
 }
 
-function handleUnregister(body: { id: string }): void {
+function handleMarkMessagesSurfaced(
+  body: MarkMessagesSurfacedRequest
+): MarkMessagesSurfacedResponse {
+  requireAgentAuth(body.id, body.auth_token);
+
+  const ids = normalizeMessageIds(body.message_ids);
+  if (ids.length === 0) {
+    return { ok: true, updated: 0 };
+  }
+
+  const surfacedAt = new Date().toISOString();
+  let updated = 0;
+
+  for (const id of ids) {
+    const result = markSurfaced.run(surfacedAt, id, body.id);
+    updated += normalizeCount(result.changes);
+  }
+
+  return { ok: true, updated };
+}
+
+function handleAcknowledgeMessages(
+  body: AcknowledgeMessagesRequest
+): AcknowledgeMessagesResponse {
+  requireAgentAuth(body.id, body.auth_token);
+
+  const ids = normalizeMessageIds(body.message_ids);
+  if (ids.length === 0) {
+    return { ok: true, updated: 0 };
+  }
+
+  const seenAt = new Date().toISOString();
+  let updated = 0;
+
+  for (const id of ids) {
+    const result = markSeen.run(seenAt, seenAt, id, body.id);
+    updated += normalizeCount(result.changes);
+  }
+
+  return { ok: true, updated };
+}
+
+function handleMessageHistory(
+  body: MessageHistoryRequest
+): MessageHistoryResponse {
+  requireAgentAuth(body.agent_id, body.auth_token);
+
+  const params: Array<string | number> = [body.agent_id, body.agent_id];
+  const clauses = ["(from_id = ? OR to_id = ?)"];
+
+  const withAgentId = normalizeOptionalText(body.with_agent_id);
+  if (withAgentId) {
+    clauses.push("(from_id = ? OR to_id = ?)");
+    params.push(withAgentId, withAgentId);
+  }
+
+  const conversationId = normalizeOptionalText(body.conversation_id);
+  if (conversationId) {
+    clauses.push("conversation_id = ?");
+    params.push(conversationId);
+  }
+
+  params.push(normalizeHistoryLimit(body.limit));
+
+  const rows = db
+    .prepare(
+      `SELECT * FROM messages WHERE ${clauses.join(
+        " AND "
+      )} ORDER BY sent_at DESC, id DESC LIMIT ?`
+    )
+    .all(...params) as MessageRow[];
+
+  return {
+    messages: rows.reverse().map(toMessage),
+  };
+}
+
+function handleUnregister(body: UnregisterRequest): void {
+  requireAgentAuth(body.id, body.auth_token);
   removeAgent(body.id);
+}
+
+function handleHealth(): BrokerHealthResponse {
+  const totals = (selectMessageTotals.get() as MessageTotalsRow | null) ?? {
+    unread_messages: 0,
+    undelivered_messages: 0,
+    surfaced_unseen_messages: 0,
+  };
+  const agents = handleListAgents({ scope: "machine" }).length;
+
+  return {
+    status: "ok",
+    agents,
+    peers: agents,
+    unread_messages: normalizeCount(totals.unread_messages),
+    undelivered_messages: normalizeCount(totals.undelivered_messages),
+    surfaced_unseen_messages: normalizeCount(totals.surfaced_unseen_messages),
+    db_path: DB_PATH,
+    primary_db_path: PRIMARY_DB_PATH,
+    db_fallback: DB_FALLBACK,
+    schema_version: getSchemaVersion(),
+  };
 }
 
 function jsonResponse(body: unknown, init?: ResponseInit): Response {
@@ -420,8 +1077,6 @@ function jsonResponse(body: unknown, init?: ResponseInit): Response {
     },
   });
 }
-
-// --- HTTP Server ---
 
 Bun.serve({
   port: PORT,
@@ -436,8 +1091,7 @@ Bun.serve({
 
     if (req.method !== "POST") {
       if (path === "/health") {
-        const agents = handleListAgents({ scope: "machine" }).length;
-        return jsonResponse({ status: "ok", agents, peers: agents });
+        return jsonResponse(handleHealth());
       }
 
       return new Response("claudy-talky broker", {
@@ -466,8 +1120,18 @@ Bun.serve({
           return jsonResponse(handleSendMessage(body as SendMessageRequest));
         case "/poll-messages":
           return jsonResponse(handlePollMessages(body as PollMessagesRequest));
+        case "/mark-messages-surfaced":
+          return jsonResponse(
+            handleMarkMessagesSurfaced(body as MarkMessagesSurfacedRequest)
+          );
+        case "/acknowledge-messages":
+          return jsonResponse(
+            handleAcknowledgeMessages(body as AcknowledgeMessagesRequest)
+          );
+        case "/message-history":
+          return jsonResponse(handleMessageHistory(body as MessageHistoryRequest));
         case "/unregister":
-          handleUnregister(body as { id: string });
+          handleUnregister(body as UnregisterRequest);
           return jsonResponse({ ok: true });
         case "/shutdown":
           setTimeout(() => process.exit(0), 50);
@@ -476,12 +1140,16 @@ Bun.serve({
           return jsonResponse({ error: "not found" }, { status: 404 });
       }
     } catch (error) {
+      if (error instanceof BrokerRequestError) {
+        return jsonResponse({ error: error.message }, { status: error.status });
+      }
+
       const message = error instanceof Error ? error.message : String(error);
       return jsonResponse({ error: message }, { status: 500 });
     }
   },
 });
 
-console.error(
-  `[claudy-talky broker] listening on 127.0.0.1:${PORT} (db: ${DB_PATH})`
+log(
+  `listening on 127.0.0.1:${PORT} (db: ${DB_PATH}${DB_FALLBACK ? `; fallback from ${PRIMARY_DB_PATH}` : ""}, schema: ${LATEST_SCHEMA_VERSION}, lock: ${LOCK_PATH})`
 );

--- a/cli.ts
+++ b/cli.ts
@@ -12,21 +12,15 @@
  *   bun cli.ts kill-broker       Stop the broker daemon
  */
 
+import { formatAgent } from "./shared/agent-format.ts";
 import { getBrokerPort } from "./shared/config.ts";
-
-type Agent = {
-  id: string;
-  name: string;
-  kind: string;
-  transport: string;
-  pid: number | null;
-  cwd: string | null;
-  git_root: string | null;
-  tty: string | null;
-  summary: string;
-  capabilities: string[];
-  last_seen: string;
-};
+import type {
+  Agent,
+  BrokerHealthResponse,
+  RegisterAgentResponse,
+  SendMessageResponse,
+  UnregisterRequest,
+} from "./shared/types.ts";
 
 const BROKER_PORT = getBrokerPort();
 const BROKER_URL = `http://127.0.0.1:${BROKER_PORT}`;
@@ -53,22 +47,22 @@ async function brokerFetch<T>(path: string, body?: unknown): Promise<T> {
 }
 
 function printAgent(agent: Agent) {
-  console.log(`${agent.id}  ${agent.name}`);
-  console.log(`  Kind: ${agent.kind}`);
-  console.log(`  Transport: ${agent.transport}`);
-  if (agent.pid !== null) {
-    console.log(`  PID: ${agent.pid}`);
-  }
-  if (agent.cwd) {
-    console.log(`  CWD: ${agent.cwd}`);
-  }
-  if (agent.summary) {
-    console.log(`  Summary: ${agent.summary}`);
-  }
-  if (agent.capabilities.length > 0) {
-    console.log(`  Capabilities: ${agent.capabilities.join(", ")}`);
-  }
-  console.log(`  Last seen: ${agent.last_seen}`);
+  console.log(formatAgent(agent));
+}
+
+async function registerCliAgent(): Promise<RegisterAgentResponse> {
+  return brokerFetch<RegisterAgentResponse>("/register-agent", {
+    name: "claudy-talky CLI",
+    kind: "cli-client",
+    transport: "cli",
+    summary: "Ephemeral CLI operator session.",
+    capabilities: ["messaging", "ephemeral"],
+    metadata: {
+      client: "claudy-talky CLI",
+      adapter: "claudy-talky",
+      notification_styles: ["stdout"],
+    },
+  });
 }
 
 const command = process.argv[2];
@@ -76,9 +70,14 @@ const command = process.argv[2];
 switch (command) {
   case "status": {
     try {
-      const health = await brokerFetch<{ status: string; agents: number }>("/health");
+      const health = await brokerFetch<BrokerHealthResponse>("/health");
       console.log(`Broker: ${health.status} (${health.agents} agent(s) connected)`);
       console.log(`URL: ${BROKER_URL}`);
+      console.log(`Schema: v${health.schema_version}`);
+      console.log(`DB: ${health.db_path}${health.db_fallback ? ` (fallback from ${health.primary_db_path})` : ""}`);
+      console.log(
+        `Messages: ${health.unread_messages} unread, ${health.undelivered_messages} pending delivery`
+      );
 
       if (health.agents > 0) {
         const agents = await brokerFetch<Agent[]>("/list-agents", {
@@ -125,23 +124,37 @@ switch (command) {
       process.exit(1);
     }
 
+    let cliAgent: RegisterAgentResponse | null = null;
+
     try {
-      const result = await brokerFetch<{ ok: boolean; error?: string }>(
-        "/send-message",
-        {
-          from_id: "cli",
-          to_id: toId,
-          text: message,
-        }
-      );
+      cliAgent = await registerCliAgent();
+      const result = await brokerFetch<SendMessageResponse>("/send-message", {
+        from_id: cliAgent.id,
+        to_id: toId,
+        text: message,
+        auth_token: cliAgent.auth_token,
+      });
 
       if (result.ok) {
-        console.log(`Message sent to ${toId}`);
+        console.log(
+          `Message sent to ${toId}${result.message ? ` (message #${result.message.id})` : ""}`
+        );
       } else {
         console.error(`Failed: ${result.error}`);
       }
     } catch (error) {
       console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      if (cliAgent) {
+        try {
+          await brokerFetch<{ ok: boolean }>("/unregister", {
+            id: cliAgent.id,
+            auth_token: cliAgent.auth_token,
+          } satisfies UnregisterRequest);
+        } catch {
+          // Best effort.
+        }
+      }
     }
     break;
   }

--- a/codex-server.ts
+++ b/codex-server.ts
@@ -8,15 +8,17 @@ await runPollingAdapter({
   logPrefix: "[claudy-talky-codex]",
   agentKind: "openai-codex",
   agentLabel: "Codex",
+  notificationStyles: ["codex-inbox"],
   instructions: `You are connected to the claudy-talky network as a Codex agent. This adapter is intended for both Codex CLI and the Codex app. Other local agents, including Claude Code sessions, can discover you and exchange messages with you.
 
-This integration uses background inbox polling. If Codex surfaces standard MCP log notifications, new messages may appear automatically. Use check_messages as the fallback inbox and to revisit unread messages.
+This integration uses background inbox polling. If Codex surfaces standard MCP log notifications, new messages may appear automatically. Use check_messages as the fallback inbox, and use message_history when you want to revisit a thread after it has already been surfaced.
 
 When collaborating with another agent:
 - call set_summary early so others can see your context
 - call check_messages before starting a long task, after major milestones, and before you finish
 - use list_agents to discover Claude, Codex, or custom agents
 - use send_message to reply with concise updates, findings, or requests
+- use reply_to_message_id or conversation_id when you want your reply to stay inside the same thread
 
 Read the message sender details returned by check_messages to understand who sent each note and respond with send_message when a reply is useful.`,
   metadata: {

--- a/examples/http-agent.ts
+++ b/examples/http-agent.ts
@@ -20,6 +20,7 @@ const AGENT_SUMMARY =
   "A simple HTTP agent that acknowledges every message it receives.";
 
 let agentId: string | null = null;
+let agentAuthToken: string | null = null;
 
 async function brokerFetch<T>(path: string, body: unknown): Promise<T> {
   const response = await fetch(`${BROKER_URL}${path}`, {
@@ -41,19 +42,33 @@ function log(message: string) {
 }
 
 async function register() {
-  const registration = await brokerFetch<{ id: string }>("/register-agent", {
+  const registration = await brokerFetch<{ id: string; auth_token?: string }>(
+    "/register-agent",
+    {
     name: AGENT_NAME,
     kind: AGENT_KIND,
     transport: "http-poll",
     summary: AGENT_SUMMARY,
-    capabilities: ["messaging", "polling", "heartbeat"],
+    capabilities: [
+      "messaging",
+      "polling",
+      "heartbeat",
+      "message_receipts",
+      "unread_counts",
+    ],
     metadata: {
       example: true,
+      client: AGENT_NAME,
+      adapter: "claudy-talky-example",
+      adapter_version: "0.4.0",
+      notification_styles: ["manual-check"],
       runtime: `bun-${Bun.version}`,
     },
-  });
+    }
+  );
 
   agentId = registration.id;
+  agentAuthToken = registration.auth_token ?? null;
   log(`Registered as ${agentId}`);
 }
 
@@ -62,7 +77,10 @@ async function heartbeat() {
     return;
   }
 
-  await brokerFetch("/heartbeat", { id: agentId });
+  await brokerFetch("/heartbeat", {
+    id: agentId,
+    auth_token: agentAuthToken ?? undefined,
+  });
 }
 
 async function poll() {
@@ -71,10 +89,19 @@ async function poll() {
   }
 
   const result = await brokerFetch<{
-    messages: Array<{ from_id: string; text: string; sent_at: string }>;
+    messages: Array<{ id: number; from_id: string; text: string; sent_at: string }>;
   }>("/poll-messages", {
     id: agentId,
+    auth_token: agentAuthToken ?? undefined,
   });
+
+  if (result.messages.length > 0) {
+    await brokerFetch("/acknowledge-messages", {
+      id: agentId,
+      message_ids: result.messages.map((message) => message.id),
+      auth_token: agentAuthToken ?? undefined,
+    });
+  }
 
   for (const message of result.messages) {
     log(`Received from ${message.from_id} at ${message.sent_at}: ${message.text}`);
@@ -84,6 +111,7 @@ async function poll() {
         from_id: agentId,
         to_id: message.from_id,
         text: `${AGENT_NAME} received: ${message.text}`,
+        auth_token: agentAuthToken ?? undefined,
       });
     } catch (error) {
       log(
@@ -99,7 +127,10 @@ async function unregister() {
   }
 
   try {
-    await brokerFetch("/unregister", { id: agentId });
+    await brokerFetch("/unregister", {
+      id: agentId,
+      auth_token: agentAuthToken ?? undefined,
+    });
     log("Unregistered");
   } catch {
     // Best effort.

--- a/google-server.ts
+++ b/google-server.ts
@@ -28,15 +28,17 @@ const config =
         logPrefix: "[claudy-talky-antigravity]",
         agentKind: "google-antigravity",
         agentLabel: "Antigravity",
+        notificationStyles: ["antigravity-inbox"],
         instructions: `You are connected to the claudy-talky network from Google Antigravity. Other local agents, including Claude Code, Codex, Gemini CLI, and custom agents, can discover you and exchange messages with you.
 
-This integration uses standard MCP tools plus background inbox polling. If Antigravity surfaces standard MCP log notifications, new messages may appear automatically. Use check_messages as the fallback inbox and to revisit unread messages.
+This integration uses standard MCP tools plus background inbox polling. If Antigravity surfaces standard MCP log notifications, new messages may appear automatically. Use check_messages as the fallback inbox, and use message_history when you want to revisit a thread after it has already been surfaced.
 
 When collaborating with another agent:
 - call set_summary early so others can see your context
 - call check_messages before starting a long task, after major milestones, and before you finish
 - use list_agents to discover Claude, Codex, Gemini, or custom agents
 - use send_message to reply with concise updates, findings, or requests
+- use reply_to_message_id or conversation_id when you want your reply to stay inside the same thread
 
 Use check_messages as your inbox whenever another agent asks you to participate in a task.`,
         metadata: {
@@ -50,15 +52,17 @@ Use check_messages as your inbox whenever another agent asks you to participate 
         logPrefix: "[claudy-talky-gemini]",
         agentKind: "google-gemini",
         agentLabel: "Gemini CLI",
+        notificationStyles: ["gemini-inbox"],
         instructions: `You are connected to the claudy-talky network from Gemini CLI. Other local agents, including Claude Code, Codex, Antigravity, and custom agents, can discover you and exchange messages with you.
 
-This integration uses standard MCP tools plus background inbox polling. If Gemini surfaces standard MCP log notifications, new messages may appear automatically. Use check_messages as the fallback inbox and to revisit unread messages.
+This integration uses standard MCP tools plus background inbox polling. If Gemini surfaces standard MCP log notifications, new messages may appear automatically. Use check_messages as the fallback inbox, and use message_history when you want to revisit a thread after it has already been surfaced.
 
 When collaborating with another agent:
 - call set_summary early so others can see your context
 - call check_messages before starting a long task, after major milestones, and before you finish
 - use list_agents to discover Claude, Codex, Antigravity, or custom agents
 - use send_message to reply with concise updates, findings, or requests
+- use reply_to_message_id or conversation_id when you want your reply to stay inside the same thread
 
 Use check_messages as your inbox whenever another agent asks you to participate in a task.`,
         metadata: {

--- a/server.ts
+++ b/server.ts
@@ -21,23 +21,29 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import { buildAgentMetadata } from "./shared/agent-metadata.ts";
+import { formatAgent } from "./shared/agent-format.ts";
+import {
+  acknowledgeMessagesCompatible,
+  brokerFetch,
+  listAgentsCompatible,
+  markMessagesSurfacedCompatible,
+  messageHistoryCompatible,
+  registerAgentCompatible,
+} from "./shared/broker-compat.ts";
 import { getBrokerPort } from "./shared/config.ts";
-import type {
-  Agent,
-  AgentId,
-  PollMessagesResponse,
-  RegisterAgentResponse,
-} from "./shared/types.ts";
 import {
   generateSummary,
   getGitBranch,
   getRecentFiles,
 } from "./shared/summarize.ts";
-import {
-  brokerFetch,
-  listAgentsCompatible,
-  registerAgentCompatible,
-} from "./shared/broker-compat.ts";
+import type {
+  Agent,
+  AgentId,
+  Message,
+  PollMessagesResponse,
+  SendMessageResponse,
+} from "./shared/types.ts";
 
 const BROKER_PORT = getBrokerPort();
 const BROKER_URL = `http://127.0.0.1:${BROKER_PORT}`;
@@ -123,42 +129,76 @@ function defaultClaudeName(cwd: string): string {
   return leaf ? `Claude Code @ ${leaf}` : "Claude Code";
 }
 
-function formatAgent(agent: Agent): string {
-  const parts = [
-    `ID: ${agent.id}`,
-    `Name: ${agent.name}`,
-    `Kind: ${agent.kind}`,
-    `Transport: ${agent.transport}`,
-  ];
-
-  if (agent.cwd) {
-    parts.push(`CWD: ${agent.cwd}`);
-  }
-  if (agent.git_root) {
-    parts.push(`Repo: ${agent.git_root}`);
-  }
-  if (agent.capabilities.length > 0) {
-    parts.push(`Capabilities: ${agent.capabilities.join(", ")}`);
-  }
-  if (agent.summary) {
-    parts.push(`Summary: ${agent.summary}`);
-  }
-  if (agent.tty) {
-    parts.push(`TTY: ${agent.tty}`);
-  }
-
-  const metadataKeys = Object.keys(agent.metadata);
-  if (metadataKeys.length > 0) {
-    parts.push(`Metadata keys: ${metadataKeys.join(", ")}`);
-  }
-
-  parts.push(`Last seen: ${agent.last_seen}`);
-  return parts.join("\n  ");
-}
+type BufferedInboxMessage = {
+  message: PollMessagesResponse["messages"][number];
+  sender: Agent | null;
+};
 
 let myId: AgentId | null = null;
+let myAuthToken: string | null = null;
 let myCwd = process.cwd();
 let myGitRoot: string | null = null;
+let bufferedInbox: BufferedInboxMessage[] = [];
+let inboxSyncPromise: Promise<void> | null = null;
+
+function withAuth<T extends object>(body: T): T & { auth_token?: string } {
+  return myAuthToken ? { ...body, auth_token: myAuthToken } : body;
+}
+
+function appendMessageStateLines(lines: string[], message: Message) {
+  lines.push(`Conversation: ${message.conversation_id}`);
+
+  if (message.reply_to_message_id !== null) {
+    lines.push(`Reply to message #${message.reply_to_message_id}`);
+  }
+
+  if (message.delivered_at) {
+    lines.push(`Delivered to inbox at ${message.delivered_at}`);
+  }
+
+  if (message.surfaced_at) {
+    lines.push(`Surfaced to client at ${message.surfaced_at}`);
+  }
+
+  if (message.seen_at) {
+    lines.push(`Marked seen at ${message.seen_at}`);
+  }
+}
+
+function formatBufferedMessage(entry: BufferedInboxMessage): string {
+  const { message, sender } = entry;
+  const label = sender
+    ? `${sender.name} (${sender.kind}, ${message.from_id})`
+    : message.from_id;
+  const details = [`Message #${message.id} from ${label} at ${message.sent_at}:`, message.text];
+  appendMessageStateLines(details, message);
+  return details.join("\n");
+}
+
+function formatHistoryMessage(
+  message: Message,
+  agentsById: Map<AgentId, Agent>,
+  selfId: AgentId
+): string {
+  const otherId = message.from_id === selfId ? message.to_id : message.from_id;
+  const otherAgent = agentsById.get(otherId);
+  const direction =
+    message.from_id === selfId
+      ? `You -> ${otherAgent?.name ?? otherId}`
+      : `${otherAgent?.name ?? message.from_id} -> you`;
+  const details = [`Message #${message.id} ${direction} at ${message.sent_at}:`, message.text];
+  appendMessageStateLines(details, message);
+  return details.join("\n");
+}
+
+async function listAgentsById(): Promise<Map<AgentId, Agent>> {
+  const agents = await listAgentsCompatible(BROKER_URL, {
+    scope: "machine",
+    cwd: myCwd,
+    git_root: myGitRoot,
+  });
+  return new Map(agents.map((agent) => [agent.id, agent]));
+}
 
 const mcp = new Server(
   { name: "claudy-talky", version: "0.4.0" },
@@ -171,11 +211,12 @@ const mcp = new Server(
 
 IMPORTANT: When you receive a <channel source="claudy-talky" ...> message, RESPOND IMMEDIATELY when a reply is appropriate. Do not wait until your current task is finished. Pause, reply with send_message, then resume your work.
 
-Read the from_id, from_name, from_kind, from_summary, and from_cwd attributes to understand who sent the message. Reply by calling send_message with their from_id.
+Read the from_id, from_name, from_kind, from_summary, and from_cwd attributes to understand who sent the message. Channel metadata also includes message_id, conversation_id, and reply_to_message_id. Reply by calling send_message with their from_id, and use reply_to_message_id or conversation_id when you want to stay in the same thread.
 
 Available tools:
 - list_agents: Discover other connected agents on this machine
 - send_message: Send a message to another agent by ID
+- message_history: Revisit recent messages or a specific conversation
 - set_summary: Set a 1-2 sentence summary of what you're working on
 - check_messages: Manually check for new messages
 
@@ -200,7 +241,7 @@ const LIST_AGENTS_SCHEMA = {
     capability: {
       type: "string" as const,
       description:
-        'Optional capability filter, such as "messaging", "channel_notifications", or "tool_use".',
+        'Optional capability filter, such as "messaging", "channel_notifications", "message_receipts", or "tool_use".',
     },
   },
   required: ["scope"],
@@ -210,7 +251,7 @@ const TOOLS = [
   {
     name: "list_agents",
     description:
-      "List other connected agents. Returns their ID, name, kind, transport, working directory, repo, and summary.",
+      "List other connected agents. Returns their ID, name, kind, transport, working directory, repo, inbox counts, and summary.",
     inputSchema: LIST_AGENTS_SCHEMA,
   },
   {
@@ -234,8 +275,40 @@ const TOOLS = [
           type: "string" as const,
           description: "The message to send",
         },
+        conversation_id: {
+          type: "string" as const,
+          description:
+            "Optional conversation ID to continue an existing thread without replying to a specific message.",
+        },
+        reply_to_message_id: {
+          type: "number" as const,
+          description:
+            "Optional message ID to reply to. This keeps the reply inside the original conversation automatically.",
+        },
       },
       required: ["to_id", "message"],
+    },
+  },
+  {
+    name: "message_history",
+    description:
+      "Show recent messages from your inbox history. Filter by agent ID or conversation ID to revisit a thread.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        with_agent_id: {
+          type: "string" as const,
+          description: "Optional other agent ID to limit history to one participant.",
+        },
+        conversation_id: {
+          type: "string" as const,
+          description: "Optional conversation ID to limit history to one thread.",
+        },
+        limit: {
+          type: "number" as const,
+          description: "Maximum number of messages to return. Defaults to 20.",
+        },
+      },
     },
   },
   {
@@ -327,7 +400,12 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
     }
 
     case "send_message": {
-      const { to_id, message } = args as { to_id: string; message: string };
+      const { to_id, message, conversation_id, reply_to_message_id } = args as {
+        to_id: string;
+        message: string;
+        conversation_id?: string;
+        reply_to_message_id?: number;
+      };
       if (!myId) {
         return {
           content: [{ type: "text" as const, text: "Not registered with broker yet" }],
@@ -336,14 +414,16 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       try {
-        const result = await brokerFetch<{ ok: boolean; error?: string }>(
+        const result = await brokerFetch<SendMessageResponse>(
           BROKER_URL,
           "/send-message",
-          {
+          withAuth({
             from_id: myId,
             to_id,
             text: message,
-          }
+            conversation_id,
+            reply_to_message_id,
+          })
         );
 
         if (!result.ok) {
@@ -362,7 +442,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
           content: [
             {
               type: "text" as const,
-              text: `Message sent to agent ${to_id}`,
+              text: `Message sent to agent ${to_id}${result.message ? ` (message #${result.message.id}, conversation ${result.message.conversation_id}${result.message.reply_to_message_id !== null ? `, reply to #${result.message.reply_to_message_id}` : ""})` : ""}`,
             },
           ],
         };
@@ -372,6 +452,61 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
             {
               type: "text" as const,
               text: `Error sending message: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+
+    case "message_history": {
+      if (!myId) {
+        return {
+          content: [{ type: "text" as const, text: "Not registered with broker yet" }],
+          isError: true,
+        };
+      }
+
+      try {
+        const { with_agent_id, conversation_id, limit } = args as {
+          with_agent_id?: string;
+          conversation_id?: string;
+          limit?: number;
+        };
+
+        const result = await messageHistoryCompatible(
+          BROKER_URL,
+          withAuth({
+            agent_id: myId,
+            with_agent_id,
+            conversation_id,
+            limit,
+          })
+        );
+
+        if (result.messages.length === 0) {
+          return {
+            content: [{ type: "text" as const, text: "No matching messages found." }],
+          };
+        }
+
+        const agentsById = await listAgentsById();
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `${result.messages.length} message(s):\n\n${result.messages
+                .map((message) => formatHistoryMessage(message, agentsById, myId!))
+                .join("\n\n---\n\n")}`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Error loading history: ${error instanceof Error ? error.message : String(error)}`,
             },
           ],
           isError: true,
@@ -389,7 +524,11 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       try {
-        await brokerFetch(BROKER_URL, "/set-summary", { id: myId, summary });
+        await brokerFetch(
+          BROKER_URL,
+          "/set-summary",
+          withAuth({ id: myId, summary })
+        );
         return {
           content: [
             {
@@ -420,36 +559,29 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       try {
-        const result = await brokerFetch<PollMessagesResponse>(BROKER_URL, "/poll-messages", {
-          id: myId,
-        });
+        await syncInbox(false);
 
-        if (result.messages.length === 0) {
+        const messages = bufferedInbox;
+        bufferedInbox = [];
+
+        if (messages.length === 0) {
           return {
             content: [{ type: "text" as const, text: "No new messages." }],
           };
         }
 
-        const agents = await listAgentsCompatible(BROKER_URL, {
-          scope: "machine",
-          cwd: myCwd,
-          git_root: myGitRoot,
-        });
-        const byId = new Map(agents.map((agent) => [agent.id, agent]));
-
-        const lines = result.messages.map((message) => {
-          const sender = byId.get(message.from_id);
-          const label = sender
-            ? `${sender.name} (${sender.kind}, ${message.from_id})`
-            : message.from_id;
-          return `From ${label} at ${message.sent_at}:\n${message.text}`;
-        });
+        await acknowledgeMessagesCompatible(BROKER_URL, withAuth({
+          id: myId,
+          message_ids: messages.map((entry) => entry.message.id),
+        }));
 
         return {
           content: [
             {
               type: "text" as const,
-              text: `${result.messages.length} new message(s):\n\n${lines.join(
+              text: `${messages.length} new message(s):\n\n${messages
+                .map(formatBufferedMessage)
+                .join(
                 "\n\n---\n\n"
               )}`,
             },
@@ -473,49 +605,94 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
   }
 });
 
+async function syncInbox(notifyClient: boolean) {
+  if (!myId) {
+    return;
+  }
+
+  if (inboxSyncPromise) {
+    await inboxSyncPromise;
+    return;
+  }
+
+  inboxSyncPromise = (async () => {
+    const result = await brokerFetch<PollMessagesResponse>(
+      BROKER_URL,
+      "/poll-messages",
+      withAuth({
+        id: myId!,
+      })
+    );
+
+    if (result.messages.length === 0) {
+      return;
+    }
+
+    const byId = await listAgentsById();
+    const arrivals = result.messages.map((message) => ({
+      message,
+      sender: byId.get(message.from_id) ?? null,
+    }));
+
+    bufferedInbox.push(...arrivals);
+
+    if (!notifyClient) {
+      return;
+    }
+
+    for (const entry of arrivals) {
+      await mcp.notification({
+        method: "notifications/claude/channel",
+        params: {
+          content: entry.message.text,
+          meta: {
+            message_id: String(entry.message.id),
+            from_id: entry.message.from_id,
+            from_name: entry.sender?.name ?? "",
+            from_kind: entry.sender?.kind ?? "",
+            from_summary: entry.sender?.summary ?? "",
+            from_cwd: entry.sender?.cwd ?? "",
+            sent_at: entry.message.sent_at,
+            delivered_at: entry.message.delivered_at ?? "",
+            conversation_id: entry.message.conversation_id,
+            reply_to_message_id:
+              entry.message.reply_to_message_id !== null
+                ? String(entry.message.reply_to_message_id)
+                : "",
+          },
+        },
+      });
+
+      log(
+        `Pushed message from ${entry.sender?.name ?? entry.message.from_id}: ${entry.message.text.slice(0, 80)}`
+      );
+    }
+
+    await markMessagesSurfacedCompatible(
+      BROKER_URL,
+      withAuth({
+        id: myId!,
+        message_ids: arrivals.map((entry) => entry.message.id),
+      })
+    );
+  })()
+    .catch((error) => {
+      log(`Poll error: ${error instanceof Error ? error.message : String(error)}`);
+    })
+    .finally(() => {
+      inboxSyncPromise = null;
+    });
+
+  await inboxSyncPromise;
+}
+
 async function pollAndPushMessages() {
   if (!myId) {
     return;
   }
 
   try {
-    const result = await brokerFetch<PollMessagesResponse>(BROKER_URL, "/poll-messages", {
-      id: myId,
-    });
-
-    if (result.messages.length === 0) {
-      return;
-    }
-
-    const agents = await listAgentsCompatible(BROKER_URL, {
-      scope: "machine",
-      cwd: myCwd,
-      git_root: myGitRoot,
-    });
-    const byId = new Map(agents.map((agent) => [agent.id, agent]));
-
-    for (const message of result.messages) {
-      const sender = byId.get(message.from_id);
-
-      await mcp.notification({
-        method: "notifications/claude/channel",
-        params: {
-          content: message.text,
-          meta: {
-            from_id: message.from_id,
-            from_name: sender?.name ?? "",
-            from_kind: sender?.kind ?? "",
-            from_summary: sender?.summary ?? "",
-            from_cwd: sender?.cwd ?? "",
-            sent_at: message.sent_at,
-          },
-        },
-      });
-
-      log(
-        `Pushed message from ${sender?.name ?? message.from_id}: ${message.text.slice(0, 80)}`
-      );
-    }
+    await syncInbox(true);
   } catch (error) {
     log(`Poll error: ${error instanceof Error ? error.message : String(error)}`);
   }
@@ -555,7 +732,10 @@ async function main() {
     }
   })();
 
-  await Promise.race([summaryPromise, new Promise((resolve) => setTimeout(resolve, 3000))]);
+  await Promise.race([
+    summaryPromise,
+    new Promise((resolve) => setTimeout(resolve, 3000)),
+  ]);
 
   const registration = await registerAgentCompatible(BROKER_URL, {
     pid: process.pid,
@@ -571,15 +751,24 @@ async function main() {
       "directory_scope",
       "repo_scope",
       "summary",
+      "message_receipts",
+      "unread_counts",
       "channel_notifications",
     ],
-    metadata: {
+    metadata: buildAgentMetadata({
       client: "Claude Code",
       adapter: "claudy-talky",
-    },
+      adapterVersion: "0.4.0",
+      notificationStyles: ["claude-channel", "manual-check"],
+      workspaceSource: "process-cwd",
+      extra: {
+        client: "Claude Code",
+      },
+    }),
   });
 
   myId = registration.id;
+  myAuthToken = registration.auth_token ?? null;
   log(`Registered as agent ${myId}`);
 
   if (!initialSummary) {
@@ -589,7 +778,14 @@ async function main() {
       }
 
       try {
-        await brokerFetch(BROKER_URL, "/set-summary", { id: myId, summary: initialSummary });
+        await brokerFetch(
+          BROKER_URL,
+          "/set-summary",
+          withAuth({
+            id: myId,
+            summary: initialSummary,
+          })
+        );
         log(`Late auto-summary applied: ${initialSummary}`);
       } catch {
         // Best effort.
@@ -607,7 +803,7 @@ async function main() {
     }
 
     try {
-      await brokerFetch(BROKER_URL, "/heartbeat", { id: myId });
+      await brokerFetch(BROKER_URL, "/heartbeat", withAuth({ id: myId }));
     } catch {
       // Best effort.
     }
@@ -619,7 +815,7 @@ async function main() {
 
     if (myId) {
       try {
-        await brokerFetch(BROKER_URL, "/unregister", { id: myId });
+        await brokerFetch(BROKER_URL, "/unregister", withAuth({ id: myId }));
         log("Unregistered from broker");
       } catch {
         // Best effort.

--- a/shared/agent-format.ts
+++ b/shared/agent-format.ts
@@ -1,0 +1,91 @@
+import type { Agent } from "./types.ts";
+
+function metadataText(
+  metadata: Record<string, unknown>,
+  key: string
+): string | null {
+  const value = metadata[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function metadataList(
+  metadata: Record<string, unknown>,
+  key: string
+): string[] {
+  const value = metadata[key];
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+}
+
+export function formatAgent(agent: Agent): string {
+  const parts = [
+    `ID: ${agent.id}`,
+    `Name: ${agent.name}`,
+    `Kind: ${agent.kind}`,
+    `Transport: ${agent.transport}`,
+  ];
+
+  if (agent.cwd) {
+    parts.push(`CWD: ${agent.cwd}`);
+  }
+  if (agent.git_root) {
+    parts.push(`Repo: ${agent.git_root}`);
+  }
+  if (agent.capabilities.length > 0) {
+    parts.push(`Capabilities: ${agent.capabilities.join(", ")}`);
+  }
+  if (agent.summary) {
+    parts.push(`Summary: ${agent.summary}`);
+  }
+  if (agent.tty) {
+    parts.push(`TTY: ${agent.tty}`);
+  }
+
+  if (
+    agent.unread_count > 0 ||
+    agent.surfaced_unseen_count > 0 ||
+    agent.delivered_unseen_count > 0 ||
+    agent.undelivered_count > 0
+  ) {
+    const inboxParts = [`${agent.unread_count} unread total`];
+    if (agent.surfaced_unseen_count > 0) {
+      inboxParts.push(`${agent.surfaced_unseen_count} surfaced`);
+    }
+    if (agent.delivered_unseen_count > 0) {
+      inboxParts.push(`${agent.delivered_unseen_count} delivered`);
+    }
+    if (agent.undelivered_count > 0) {
+      inboxParts.push(`${agent.undelivered_count} pending delivery`);
+    }
+    parts.push(`Inbox: ${inboxParts.join(", ")}`);
+  }
+
+  const client = metadataText(agent.metadata, "client");
+  const clientVersion = metadataText(agent.metadata, "client_version");
+  const launcher = metadataText(agent.metadata, "launcher");
+  const adapter = metadataText(agent.metadata, "adapter");
+  const adapterVersion = metadataText(agent.metadata, "adapter_version");
+  const workspaceSource = metadataText(agent.metadata, "workspace_source");
+  const notificationStyles = metadataList(agent.metadata, "notification_styles");
+
+  if (client) {
+    parts.push(
+      `Client: ${client}${clientVersion ? ` ${clientVersion}` : ""}${adapter ? ` via ${adapter}${adapterVersion ? ` ${adapterVersion}` : ""}` : ""}`
+    );
+  }
+  if (launcher) {
+    parts.push(`Launcher: ${launcher}`);
+  }
+  if (notificationStyles.length > 0) {
+    parts.push(`Notifications: ${notificationStyles.join(", ")}`);
+  }
+  if (workspaceSource) {
+    parts.push(`Workspace source: ${workspaceSource}`);
+  }
+
+  parts.push(`Last seen: ${agent.last_seen}`);
+  return parts.join("\n  ");
+}

--- a/shared/agent-metadata.ts
+++ b/shared/agent-metadata.ts
@@ -1,0 +1,122 @@
+export type WorkspaceSource = "process-cwd" | "mcp-roots";
+
+type AgentMetadataOptions = {
+  client: string;
+  adapter: string;
+  adapterVersion: string;
+  clientVersion?: string | null;
+  launcher?: string;
+  notificationStyles?: string[];
+  workspaceSource?: WorkspaceSource;
+  extra?: Record<string, unknown>;
+};
+
+function normalizeText(value: string | null | undefined): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const text = value.trim();
+  return text.length > 0 ? text : null;
+}
+
+function normalizeNotificationStyles(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const seen = new Set<string>();
+  const styles: string[] = [];
+
+  for (const item of value) {
+    const style = normalizeText(typeof item === "string" ? item : null);
+    if (!style || seen.has(style)) {
+      continue;
+    }
+
+    seen.add(style);
+    styles.push(style);
+  }
+
+  return styles;
+}
+
+export function detectLauncherType(explicit?: string): string {
+  const preferred = normalizeText(explicit);
+  if (preferred) {
+    return preferred;
+  }
+
+  if (process.env.VSCODE_PID) {
+    return "vscode";
+  }
+
+  if (process.env.WT_SESSION) {
+    return "windows-terminal";
+  }
+
+  const termProgram = normalizeText(process.env.TERM_PROGRAM);
+  if (termProgram) {
+    return termProgram.toLowerCase();
+  }
+
+  const terminalEmulator = normalizeText(process.env.TERMINAL_EMULATOR);
+  if (terminalEmulator) {
+    return terminalEmulator.toLowerCase();
+  }
+
+  if (process.env.SSH_TTY) {
+    return "ssh";
+  }
+
+  return process.platform === "win32" ? "windows-stdio" : "stdio";
+}
+
+export function buildAgentMetadata(
+  options: AgentMetadataOptions
+): Record<string, unknown> {
+  const extra = options.extra ?? {};
+  const notificationStyles = normalizeNotificationStyles([
+    ...normalizeNotificationStyles(extra.notification_styles),
+    ...(options.notificationStyles ?? []),
+  ]);
+
+  const metadata: Record<string, unknown> = {
+    ...extra,
+    client: options.client,
+    adapter: options.adapter,
+    adapter_version: options.adapterVersion,
+    launcher: detectLauncherType(options.launcher),
+    workspace_source: options.workspaceSource ?? "process-cwd",
+    platform: process.platform,
+    runtime: "bun",
+    runtime_version: Bun.version,
+  };
+
+  const clientVersion = normalizeText(options.clientVersion);
+  if (clientVersion) {
+    metadata.client_version = clientVersion;
+  }
+
+  if (notificationStyles.length > 0) {
+    metadata.notification_styles = notificationStyles;
+  }
+
+  return Object.fromEntries(
+    Object.entries(metadata).filter(([, value]) => {
+      if (value === null || value === undefined) {
+        return false;
+      }
+
+      if (typeof value === "string") {
+        return value.trim().length > 0;
+      }
+
+      if (Array.isArray(value)) {
+        return value.length > 0;
+      }
+
+      return true;
+    })
+  );
+}

--- a/shared/broker-compat.ts
+++ b/shared/broker-compat.ts
@@ -1,7 +1,13 @@
 import { basename } from "node:path";
 import type {
+  AcknowledgeMessagesRequest,
+  AcknowledgeMessagesResponse,
   Agent,
   ListAgentsRequest,
+  MarkMessagesSurfacedRequest,
+  MarkMessagesSurfacedResponse,
+  MessageHistoryRequest,
+  MessageHistoryResponse,
   RegisterAgentRequest,
   RegisterAgentResponse,
 } from "./types.ts";
@@ -47,6 +53,10 @@ function toAgent(entry: Agent | LegacyPeer): Agent {
       cwd: entry.cwd ?? null,
       git_root: entry.git_root ?? null,
       tty: entry.tty ?? null,
+      unread_count: entry.unread_count ?? 0,
+      undelivered_count: entry.undelivered_count ?? 0,
+      delivered_unseen_count: entry.delivered_unseen_count ?? 0,
+      surfaced_unseen_count: entry.surfaced_unseen_count ?? 0,
     };
   }
 
@@ -64,6 +74,10 @@ function toAgent(entry: Agent | LegacyPeer): Agent {
     summary: entry.summary ?? "",
     capabilities: ["messaging", "directory_scope", "repo_scope", "summary"],
     metadata: { legacyBroker: true },
+    unread_count: 0,
+    undelivered_count: 0,
+    delivered_unseen_count: 0,
+    surfaced_unseen_count: 0,
     registered_at: entry.registered_at,
     last_seen: entry.last_seen,
   };
@@ -135,5 +149,62 @@ export async function listAgentsCompatible(
     }
 
     return agents;
+  }
+}
+
+export async function acknowledgeMessagesCompatible(
+  brokerUrl: string,
+  body: AcknowledgeMessagesRequest
+): Promise<AcknowledgeMessagesResponse> {
+  try {
+    return await brokerFetch<AcknowledgeMessagesResponse>(
+      brokerUrl,
+      "/acknowledge-messages",
+      body
+    );
+  } catch (error) {
+    if (!(error instanceof BrokerApiError) || error.status !== 404) {
+      throw error;
+    }
+
+    return { ok: true, updated: 0 };
+  }
+}
+
+export async function markMessagesSurfacedCompatible(
+  brokerUrl: string,
+  body: MarkMessagesSurfacedRequest
+): Promise<MarkMessagesSurfacedResponse> {
+  try {
+    return await brokerFetch<MarkMessagesSurfacedResponse>(
+      brokerUrl,
+      "/mark-messages-surfaced",
+      body
+    );
+  } catch (error) {
+    if (!(error instanceof BrokerApiError) || error.status !== 404) {
+      throw error;
+    }
+
+    return { ok: true, updated: 0 };
+  }
+}
+
+export async function messageHistoryCompatible(
+  brokerUrl: string,
+  body: MessageHistoryRequest
+): Promise<MessageHistoryResponse> {
+  try {
+    return await brokerFetch<MessageHistoryResponse>(
+      brokerUrl,
+      "/message-history",
+      body
+    );
+  } catch (error) {
+    if (!(error instanceof BrokerApiError) || error.status !== 404) {
+      throw error;
+    }
+
+    return { messages: [] };
   }
 }

--- a/shared/config.ts
+++ b/shared/config.ts
@@ -1,4 +1,4 @@
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 
 const DEFAULT_PORT = 7899;
@@ -47,6 +47,22 @@ export function getBrokerPort(): number {
 
 export function getDbPath(): string {
   return firstEnv("CLAUDY_TALKY_DB", "CLAUDE_PEERS_DB") ?? getDefaultDbPath();
+}
+
+export function getDbFallbackPaths(cwd = process.cwd()): string[] {
+  const candidates = [
+    getDbPath(),
+    join(cwd, ".claudy-talky.db"),
+    join(tmpdir(), "claudy-talky", `claudy-talky-${getBrokerPort()}.db`),
+  ];
+
+  return Array.from(
+    new Set(candidates.filter((value) => value && value.trim().length > 0))
+  );
+}
+
+export function getBrokerLockPath(port = getBrokerPort()): string {
+  return join(tmpdir(), "claudy-talky", `broker-${port}.lock`);
 }
 
 export function getStaleAgentMs(): number {

--- a/shared/desktop-notify.ts
+++ b/shared/desktop-notify.ts
@@ -1,0 +1,107 @@
+type DesktopNotification = {
+  title: string;
+  body: string;
+};
+
+function normalizeText(value: string, maxLength: number): string {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, Math.max(0, maxLength - 1))}…`;
+}
+
+function powershellQuote(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+function applescriptQuote(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function encodePowerShell(script: string): string {
+  return Buffer.from(script, "utf16le").toString("base64");
+}
+
+export function desktopNotificationsEnabled(): boolean {
+  const raw = process.env.CLAUDY_TALKY_DESKTOP_NOTIFICATIONS?.trim().toLowerCase();
+  if (!raw) {
+    return true;
+  }
+
+  return !["0", "false", "off", "no", "disabled"].includes(raw);
+}
+
+export async function sendDesktopNotification(
+  notification: DesktopNotification
+): Promise<boolean> {
+  if (!desktopNotificationsEnabled()) {
+    return false;
+  }
+
+  const title = normalizeText(notification.title, 80) || "claudy-talky";
+  const body = normalizeText(notification.body, 240) || "New claudy-talky message";
+
+  try {
+    let processHandle: ReturnType<typeof Bun.spawn>;
+
+    switch (process.platform) {
+      case "darwin":
+        processHandle = Bun.spawn(
+          [
+            "osascript",
+            "-e",
+            `display notification "${applescriptQuote(body)}" with title "${applescriptQuote(title)}"`,
+          ],
+          {
+            stdio: ["ignore", "ignore", "ignore"],
+          }
+        );
+        break;
+      case "linux":
+        processHandle = Bun.spawn(["notify-send", title, body], {
+          stdio: ["ignore", "ignore", "ignore"],
+        });
+        break;
+      case "win32": {
+        const script = `
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+$notify = New-Object System.Windows.Forms.NotifyIcon
+$notify.Icon = [System.Drawing.SystemIcons]::Information
+$notify.BalloonTipTitle = '${powershellQuote(title)}'
+$notify.BalloonTipText = '${powershellQuote(body)}'
+$notify.Visible = $true
+$notify.ShowBalloonTip(5000)
+Start-Sleep -Milliseconds 5500
+$notify.Dispose()
+`;
+
+        processHandle = Bun.spawn(
+          [
+            "powershell",
+            "-NoProfile",
+            "-NonInteractive",
+            "-WindowStyle",
+            "Hidden",
+            "-EncodedCommand",
+            encodePowerShell(script),
+          ],
+          {
+            stdio: ["ignore", "ignore", "ignore"],
+            windowsHide: true,
+          }
+        );
+        break;
+      }
+      default:
+        return false;
+    }
+
+    processHandle.unref();
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/shared/polling-adapter.ts
+++ b/shared/polling-adapter.ts
@@ -6,23 +6,33 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import { buildAgentMetadata } from "./agent-metadata.ts";
+import { formatAgent } from "./agent-format.ts";
+import {
+  acknowledgeMessagesCompatible,
+  brokerFetch,
+  listAgentsCompatible,
+  markMessagesSurfacedCompatible,
+  messageHistoryCompatible,
+  registerAgentCompatible,
+} from "./broker-compat.ts";
 import { getBrokerPort } from "./config.ts";
-import type {
-  Agent,
-  AgentId,
-  PollMessagesResponse,
-  RegisterAgentResponse,
-} from "./types.ts";
+import {
+  desktopNotificationsEnabled,
+  sendDesktopNotification,
+} from "./desktop-notify.ts";
 import {
   generateSummary,
   getGitBranch,
   getRecentFiles,
 } from "./summarize.ts";
-import {
-  brokerFetch,
-  listAgentsCompatible,
-  registerAgentCompatible,
-} from "./broker-compat.ts";
+import type {
+  Agent,
+  AgentId,
+  Message,
+  PollMessagesResponse,
+  SendMessageResponse,
+} from "./types.ts";
 import { resolveWorkspaceCwdFromRootUris } from "./workspace.ts";
 
 const HEARTBEAT_INTERVAL_MS = 15_000;
@@ -45,7 +55,7 @@ const LIST_AGENTS_SCHEMA = {
     capability: {
       type: "string" as const,
       description:
-        'Optional agent capability filter, such as "messaging", "manual_message_polling", or "channel_notifications".',
+        'Optional agent capability filter, such as "messaging", "manual_message_polling", "message_receipts", or "channel_notifications".',
     },
   },
   required: ["scope"],
@@ -60,6 +70,10 @@ export type PollingAdapterOptions = {
   instructions: string;
   agentTransport?: string;
   capabilities?: string[];
+  clientVersion?: string | null;
+  launcher?: string;
+  notificationStyles?: string[];
+  enableDesktopNotifications?: boolean;
   metadata?: Record<string, unknown>;
 };
 
@@ -85,7 +99,10 @@ function createLogger(prefix: string) {
   };
 }
 
-async function ensureBroker(brokerUrl: string, log: (message: string) => void): Promise<void> {
+async function ensureBroker(
+  brokerUrl: string,
+  log: (message: string) => void
+): Promise<void> {
   if (await isBrokerAlive(brokerUrl)) {
     log("Broker already running");
     return;
@@ -149,32 +166,24 @@ function defaultAgentName(label: string, cwd: string): string {
   return leaf ? `${label} @ ${leaf}` : label;
 }
 
-function formatAgent(agent: Agent): string {
-  const parts = [
-    `ID: ${agent.id}`,
-    `Name: ${agent.name}`,
-    `Kind: ${agent.kind}`,
-    `Transport: ${agent.transport}`,
-  ];
+function appendMessageStateLines(lines: string[], message: Message) {
+  lines.push(`Conversation: ${message.conversation_id}`);
 
-  if (agent.cwd) {
-    parts.push(`CWD: ${agent.cwd}`);
-  }
-  if (agent.git_root) {
-    parts.push(`Repo: ${agent.git_root}`);
-  }
-  if (agent.capabilities.length > 0) {
-    parts.push(`Capabilities: ${agent.capabilities.join(", ")}`);
-  }
-  if (agent.summary) {
-    parts.push(`Summary: ${agent.summary}`);
-  }
-  if (agent.tty) {
-    parts.push(`TTY: ${agent.tty}`);
+  if (message.reply_to_message_id !== null) {
+    lines.push(`Reply to message #${message.reply_to_message_id}`);
   }
 
-  parts.push(`Last seen: ${agent.last_seen}`);
-  return parts.join("\n  ");
+  if (message.delivered_at) {
+    lines.push(`Delivered to inbox at ${message.delivered_at}`);
+  }
+
+  if (message.surfaced_at) {
+    lines.push(`Surfaced to client at ${message.surfaced_at}`);
+  }
+
+  if (message.seen_at) {
+    lines.push(`Marked seen at ${message.seen_at}`);
+  }
 }
 
 function formatBufferedMessage(entry: BufferedInboxMessage): string {
@@ -182,7 +191,10 @@ function formatBufferedMessage(entry: BufferedInboxMessage): string {
   const label = sender
     ? `${sender.name} (${sender.kind}, ${message.from_id})`
     : message.from_id;
-  return `From ${label} at ${message.sent_at}:\n${message.text}`;
+  const details = [`Message #${message.id} from ${label} at ${message.sent_at}:`, message.text];
+  appendMessageStateLines(details, message);
+
+  return details.join("\n");
 }
 
 function formatInboxNotification(entry: BufferedInboxMessage): string {
@@ -192,6 +204,13 @@ function formatInboxNotification(entry: BufferedInboxMessage): string {
     : `New claudy-talky message from ${message.from_id}`;
   const details: string[] = [header, "", message.text];
 
+  details.push("", `Message ID: ${message.id}`);
+  details.push("", `Conversation: ${message.conversation_id}`);
+
+  if (message.reply_to_message_id !== null) {
+    details.push(`Reply to message #${message.reply_to_message_id}`);
+  }
+
   if (sender?.summary) {
     details.push("", `Sender summary: ${sender.summary}`);
   }
@@ -200,7 +219,29 @@ function formatInboxNotification(entry: BufferedInboxMessage): string {
     details.push(`Sender cwd: ${sender.cwd}`);
   }
 
-  details.push('Use `check_messages` if you want to review the unread inbox again.');
+  if (message.delivered_at) {
+    details.push(`Delivered to your inbox at: ${message.delivered_at}`);
+  }
+
+  details.push(
+    'Use `check_messages` to mark unread notes as seen, or `message_history` to revisit the thread later.'
+  );
+  return details.join("\n");
+}
+
+function formatHistoryMessage(
+  message: Message,
+  agentsById: Map<AgentId, Agent>,
+  myId: AgentId
+): string {
+  const otherId = message.from_id === myId ? message.to_id : message.from_id;
+  const otherAgent = agentsById.get(otherId);
+  const direction =
+    message.from_id === myId
+      ? `You -> ${otherAgent?.name ?? otherId}`
+      : `${otherAgent?.name ?? message.from_id} -> you`;
+  const details = [`Message #${message.id} ${direction} at ${message.sent_at}:`, message.text];
+  appendMessageStateLines(details, message);
   return details.join("\n");
 }
 
@@ -234,22 +275,33 @@ async function resolveWorkspaceCwd(
   }
 }
 
-export async function runPollingAdapter(options: PollingAdapterOptions): Promise<void> {
+export async function runPollingAdapter(
+  options: PollingAdapterOptions
+): Promise<void> {
   const brokerUrl = `http://127.0.0.1:${getBrokerPort()}`;
   const log = createLogger(options.logPrefix);
 
   let myId: AgentId | null = null;
+  let myAuthToken: string | null = null;
   let myCwd = process.cwd();
   let myGitRoot: string | null = null;
+  let workspaceSource: "process-cwd" | "mcp-roots" = "process-cwd";
   let bufferedInbox: BufferedInboxMessage[] = [];
   let inboxSyncPromise: Promise<void> | null = null;
+  let desktopNotificationWarningLogged = false;
+
+  const desktopNotifications =
+    options.enableDesktopNotifications ?? desktopNotificationsEnabled();
 
   const capabilities = [
     "messaging",
     "directory_scope",
     "repo_scope",
     "summary",
+    "message_receipts",
+    "unread_counts",
     "manual_message_polling",
+    ...(desktopNotifications ? ["desktop_notifications"] : []),
     ...(options.capabilities ?? []),
   ];
 
@@ -257,7 +309,7 @@ export async function runPollingAdapter(options: PollingAdapterOptions): Promise
     {
       name: "list_agents",
       description:
-        "List other connected agents. Returns their ID, name, kind, transport, working directory, repo, and summary.",
+        "List other connected agents. Returns their ID, name, kind, transport, working directory, repo, inbox counts, and summary.",
       inputSchema: LIST_AGENTS_SCHEMA,
     },
     {
@@ -281,8 +333,40 @@ export async function runPollingAdapter(options: PollingAdapterOptions): Promise
             type: "string" as const,
             description: "The message to send",
           },
+          conversation_id: {
+            type: "string" as const,
+            description:
+              "Optional conversation ID to continue an existing thread without replying to a specific message.",
+          },
+          reply_to_message_id: {
+            type: "number" as const,
+            description:
+              "Optional message ID to reply to. This keeps the reply inside the original conversation automatically.",
+          },
         },
         required: ["to_id", "message"],
+      },
+    },
+    {
+      name: "message_history",
+      description:
+        "Show recent messages from your inbox history. Filter by agent ID or conversation ID to revisit a thread.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          with_agent_id: {
+            type: "string" as const,
+            description: "Optional other agent ID to limit history to one participant.",
+          },
+          conversation_id: {
+            type: "string" as const,
+            description: "Optional conversation ID to limit history to one thread.",
+          },
+          limit: {
+            type: "number" as const,
+            description: "Maximum number of messages to return. Defaults to 20.",
+          },
+        },
       },
     },
     {
@@ -303,7 +387,7 @@ export async function runPollingAdapter(options: PollingAdapterOptions): Promise
     {
       name: "check_messages",
       description:
-        "Check unread messages from other agents. This adapter also polls in the background and may surface standard MCP log notifications when the client supports them.",
+        "Check unread messages from other agents. This adapter also polls in the background and may surface standard MCP log notifications or desktop notifications when available.",
       inputSchema: {
         type: "object" as const,
         properties: {},
@@ -331,6 +415,10 @@ export async function runPollingAdapter(options: PollingAdapterOptions): Promise
     return new Map(agents.map((agent) => [agent.id, agent]));
   }
 
+  function withAuth<T extends object>(body: T): T & { auth_token?: string } {
+    return myAuthToken ? { ...body, auth_token: myAuthToken } : body;
+  }
+
   async function syncInbox(notifyClient: boolean): Promise<void> {
     if (!myId) {
       return;
@@ -342,9 +430,13 @@ export async function runPollingAdapter(options: PollingAdapterOptions): Promise
     }
 
     inboxSyncPromise = (async () => {
-      const result = await brokerFetch<PollMessagesResponse>(brokerUrl, "/poll-messages", {
-        id: myId!,
-      });
+      const result = await brokerFetch<PollMessagesResponse>(
+        brokerUrl,
+        "/poll-messages",
+        withAuth({
+          id: myId!,
+        })
+      );
 
       if (result.messages.length === 0) {
         return;
@@ -369,13 +461,37 @@ export async function runPollingAdapter(options: PollingAdapterOptions): Promise
           data: formatInboxNotification(entry),
         });
 
+        if (desktopNotifications) {
+          const notified = await sendDesktopNotification({
+            title: entry.sender
+              ? `claudy-talky: ${entry.sender.name}`
+              : `claudy-talky: ${entry.message.from_id}`,
+            body: entry.message.text,
+          });
+
+          if (!notified && !desktopNotificationWarningLogged) {
+            log("Desktop notification fallback was unavailable");
+            desktopNotificationWarningLogged = true;
+          }
+        }
+
         log(
           `Notified inbound message from ${entry.sender?.name ?? entry.message.from_id}: ${entry.message.text.slice(0, 80)}`
         );
       }
+
+      await markMessagesSurfacedCompatible(
+        brokerUrl,
+        withAuth({
+          id: myId!,
+          message_ids: arrivals.map((entry) => entry.message.id),
+        })
+      );
     })()
       .catch((error) => {
-        log(`Inbox sync error: ${error instanceof Error ? error.message : String(error)}`);
+        log(
+          `Inbox sync error: ${error instanceof Error ? error.message : String(error)}`
+        );
       })
       .finally(() => {
         inboxSyncPromise = null;
@@ -447,7 +563,12 @@ export async function runPollingAdapter(options: PollingAdapterOptions): Promise
       }
 
       case "send_message": {
-        const { to_id, message } = args as { to_id: string; message: string };
+        const { to_id, message, conversation_id, reply_to_message_id } = args as {
+          to_id: string;
+          message: string;
+          conversation_id?: string;
+          reply_to_message_id?: number;
+        };
         if (!myId) {
           return {
             content: [{ type: "text" as const, text: "Not registered with broker yet" }],
@@ -456,14 +577,16 @@ export async function runPollingAdapter(options: PollingAdapterOptions): Promise
         }
 
         try {
-          const result = await brokerFetch<{ ok: boolean; error?: string }>(
+          const result = await brokerFetch<SendMessageResponse>(
             brokerUrl,
             "/send-message",
-            {
+            withAuth({
               from_id: myId,
               to_id,
               text: message,
-            }
+              conversation_id,
+              reply_to_message_id,
+            })
           );
 
           if (!result.ok) {
@@ -482,7 +605,7 @@ export async function runPollingAdapter(options: PollingAdapterOptions): Promise
             content: [
               {
                 type: "text" as const,
-                text: `Message sent to agent ${to_id}`,
+                text: `Message sent to agent ${to_id}${result.message ? ` (message #${result.message.id}, conversation ${result.message.conversation_id}${result.message.reply_to_message_id !== null ? `, reply to #${result.message.reply_to_message_id}` : ""})` : ""}`,
               },
             ],
           };
@@ -492,6 +615,61 @@ export async function runPollingAdapter(options: PollingAdapterOptions): Promise
               {
                 type: "text" as const,
                 text: `Error sending message: ${error instanceof Error ? error.message : String(error)}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+      }
+
+      case "message_history": {
+        if (!myId) {
+          return {
+            content: [{ type: "text" as const, text: "Not registered with broker yet" }],
+            isError: true,
+          };
+        }
+
+        try {
+          const { with_agent_id, conversation_id, limit } = args as {
+            with_agent_id?: string;
+            conversation_id?: string;
+            limit?: number;
+          };
+
+          const result = await messageHistoryCompatible(
+            brokerUrl,
+            withAuth({
+              agent_id: myId,
+              with_agent_id,
+              conversation_id,
+              limit,
+            })
+          );
+
+          if (result.messages.length === 0) {
+            return {
+              content: [{ type: "text" as const, text: "No matching messages found." }],
+            };
+          }
+
+          const agentsById = await listAgentsById();
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `${result.messages.length} message(s):\n\n${result.messages
+                  .map((message) => formatHistoryMessage(message, agentsById, myId!))
+                  .join("\n\n---\n\n")}`,
+              },
+            ],
+          };
+        } catch (error) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Error loading history: ${error instanceof Error ? error.message : String(error)}`,
               },
             ],
             isError: true,
@@ -509,7 +687,11 @@ export async function runPollingAdapter(options: PollingAdapterOptions): Promise
         }
 
         try {
-          await brokerFetch(brokerUrl, "/set-summary", { id: myId, summary });
+          await brokerFetch(
+            brokerUrl,
+            "/set-summary",
+            withAuth({ id: myId, summary })
+          );
           return {
             content: [
               {
@@ -551,15 +733,18 @@ export async function runPollingAdapter(options: PollingAdapterOptions): Promise
             };
           }
 
+          await acknowledgeMessagesCompatible(brokerUrl, withAuth({
+            id: myId,
+            message_ids: messages.map((entry) => entry.message.id),
+          }));
+
           return {
             content: [
               {
                 type: "text" as const,
                 text: `${messages.length} new message(s):\n\n${messages
                   .map(formatBufferedMessage)
-                  .join(
-                  "\n\n---\n\n"
-                )}`,
+                  .join("\n\n---\n\n")}`,
               },
             ],
           };
@@ -589,6 +774,7 @@ export async function runPollingAdapter(options: PollingAdapterOptions): Promise
   log("MCP connected");
 
   myCwd = await resolveWorkspaceCwd(mcp, process.cwd(), log);
+  workspaceSource = myCwd === process.cwd() ? "process-cwd" : "mcp-roots";
   myGitRoot = await getGitRoot(myCwd);
 
   log(`CWD: ${myCwd}`);
@@ -618,7 +804,10 @@ export async function runPollingAdapter(options: PollingAdapterOptions): Promise
     }
   })();
 
-  await Promise.race([summaryPromise, new Promise((resolve) => setTimeout(resolve, 3000))]);
+  await Promise.race([
+    summaryPromise,
+    new Promise((resolve) => setTimeout(resolve, 3000)),
+  ]);
 
   const registration = await registerAgentCompatible(brokerUrl, {
     pid: process.pid,
@@ -630,10 +819,28 @@ export async function runPollingAdapter(options: PollingAdapterOptions): Promise
     tty,
     summary: initialSummary,
     capabilities,
-    metadata: options.metadata ?? {},
+    metadata: buildAgentMetadata({
+      client:
+        typeof options.metadata?.client === "string"
+          ? options.metadata.client
+          : options.agentLabel,
+      adapter: "claudy-talky",
+      adapterVersion: options.serverVersion,
+      clientVersion: options.clientVersion,
+      launcher: options.launcher,
+      notificationStyles: [
+        "manual-check",
+        "mcp-logging",
+        ...(desktopNotifications ? ["desktop-toast"] : []),
+        ...(options.notificationStyles ?? []),
+      ],
+      workspaceSource,
+      extra: options.metadata,
+    }),
   });
 
   myId = registration.id;
+  myAuthToken = registration.auth_token ?? null;
   log(`Registered as agent ${myId}`);
 
   if (!initialSummary) {
@@ -643,7 +850,14 @@ export async function runPollingAdapter(options: PollingAdapterOptions): Promise
       }
 
       try {
-        await brokerFetch(brokerUrl, "/set-summary", { id: myId, summary: initialSummary });
+        await brokerFetch(
+          brokerUrl,
+          "/set-summary",
+          withAuth({
+            id: myId,
+            summary: initialSummary,
+          })
+        );
         log(`Late auto-summary applied: ${initialSummary}`);
       } catch {
         // Best effort.
@@ -661,7 +875,7 @@ export async function runPollingAdapter(options: PollingAdapterOptions): Promise
     }
 
     try {
-      await brokerFetch(brokerUrl, "/heartbeat", { id: myId });
+      await brokerFetch(brokerUrl, "/heartbeat", withAuth({ id: myId }));
     } catch {
       // Best effort.
     }
@@ -673,7 +887,7 @@ export async function runPollingAdapter(options: PollingAdapterOptions): Promise
 
     if (myId) {
       try {
-        await brokerFetch(brokerUrl, "/unregister", { id: myId });
+        await brokerFetch(brokerUrl, "/unregister", withAuth({ id: myId }));
         log("Unregistered from broker");
       } catch {
         // Best effort.

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -13,6 +13,10 @@ export interface Agent {
   summary: string;
   capabilities: string[];
   metadata: Record<string, unknown>;
+  unread_count: number;
+  undelivered_count: number;
+  delivered_unseen_count: number;
+  surfaced_unseen_count: number;
   registered_at: string;
   last_seen: string;
 }
@@ -23,7 +27,12 @@ export interface Message {
   to_id: AgentId;
   text: string;
   sent_at: string;
+  conversation_id: string;
+  reply_to_message_id: number | null;
   delivered: boolean;
+  delivered_at: string | null;
+  surfaced_at: string | null;
+  seen_at: string | null;
 }
 
 export interface RegisterAgentRequest {
@@ -41,15 +50,18 @@ export interface RegisterAgentRequest {
 
 export interface RegisterAgentResponse {
   id: AgentId;
+  auth_token?: string;
 }
 
 export interface HeartbeatRequest {
   id: AgentId;
+  auth_token?: string;
 }
 
 export interface SetSummaryRequest {
   id: AgentId;
   summary: string;
+  auth_token?: string;
 }
 
 export interface ListAgentsRequest {
@@ -65,14 +77,76 @@ export interface SendMessageRequest {
   from_id: AgentId;
   to_id: AgentId;
   text: string;
+  conversation_id?: string;
+  reply_to_message_id?: number | null;
+  auth_token?: string;
+}
+
+export interface SendMessageResponse {
+  ok: boolean;
+  error?: string;
+  message?: Message;
 }
 
 export interface PollMessagesRequest {
   id: AgentId;
+  auth_token?: string;
 }
 
 export interface PollMessagesResponse {
   messages: Message[];
+}
+
+export interface MarkMessagesSurfacedRequest {
+  id: AgentId;
+  message_ids: number[];
+  auth_token?: string;
+}
+
+export interface MarkMessagesSurfacedResponse {
+  ok: boolean;
+  updated: number;
+}
+
+export interface AcknowledgeMessagesRequest {
+  id: AgentId;
+  message_ids: number[];
+  auth_token?: string;
+}
+
+export interface AcknowledgeMessagesResponse {
+  ok: boolean;
+  updated: number;
+}
+
+export interface MessageHistoryRequest {
+  agent_id: AgentId;
+  with_agent_id?: AgentId;
+  conversation_id?: string;
+  limit?: number;
+  auth_token?: string;
+}
+
+export interface MessageHistoryResponse {
+  messages: Message[];
+}
+
+export interface UnregisterRequest {
+  id: AgentId;
+  auth_token?: string;
+}
+
+export interface BrokerHealthResponse {
+  status: "ok";
+  agents: number;
+  peers: number;
+  unread_messages: number;
+  undelivered_messages: number;
+  surfaced_unseen_messages: number;
+  db_path: string;
+  primary_db_path: string;
+  db_fallback: boolean;
+  schema_version: number;
 }
 
 // Legacy aliases so older integrations can continue compiling against the


### PR DESCRIPTION
## What changed

This PR turns the current local `claudy-talky` work into a more durable multi-agent messaging layer.

It includes:

- broker hardening with per-agent auth tokens, schema-versioned migrations, a startup lock, and Windows-friendly DB fallback behavior
- richer agent metadata, inbox counts, and desktop notification fallback for polling-based clients
- conversation-aware messaging with `conversation_id`, `reply_to_message_id`, `message_history`, and a separate `surfaced_at` receipt before `seen_at`
- adapter updates for Claude, Codex, Gemini, and Antigravity so background delivery stays available in a local unread buffer until `check_messages` marks it seen
- updated CLI, example agent, tests, and docs for the new broker and receipt flow

## Why

`claudy-talky` already worked as a local message bus, but it still had a few rough edges: easy agent spoofing, brittle startup behavior on Windows, ambiguous receipt state, and no real way to keep a conversation together after a polling client had already surfaced a message.

This PR tightens the broker and makes collaboration feel more like an actual threaded inbox instead of a one-shot queue.

## Impact

- Agents can authenticate broker-scoped actions instead of trusting only the public agent ID.
- Operators get more reliable broker startup and better visibility into unread, delivered, and surfaced message state.
- Claude and polling-based clients can keep replies in-thread and revisit older threads with `message_history`.
- Non-Claude clients can surface messages automatically without losing them from the manual inbox flow.

## Validation

- `bun x tsc --noEmit`
- `bun test`

## What remains

- Add a stronger “human actually opened/read this” signal beyond “surfaced to the client” and “checked via tool.”
- Add end-to-end adapter tests for Claude, Codex, Gemini, and Antigravity behavior, not just broker-level tests.
- Add one-command setup/install helpers that write the MCP config for each client automatically.
- Add a small dashboard or TUI for agents, unread counts, and recent thread activity.
- Explore an experimental `z.ai` wrapper if we want to support that path later.
