### PR TITLE
fix: stabilize operator.ts on Windows Terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Click a room row             Open that room
 Tab / Shift+Tab              Cycle panes, including Actions
 Left / Right                 Move across the Actions strip
 Enter                        Run the selected Action or send composer text
-Esc                          Clear the composer and leave edit mode
+Esc                          Leave edit mode and preserve the current draft
 Ctrl+A                       Jump straight to the Actions strip
 x                            Jump to the Actions strip
 v                            Cycle minimal, compact, and verbose message details

--- a/operator.ts
+++ b/operator.ts
@@ -17,6 +17,7 @@ import {
   resolveAgentSelector,
   type AgentRefRecord,
 } from "./shared/operator-agent-ref.ts";
+import { resolveRoomParticipantIds } from "./shared/operator-room.ts";
 import {
   operatorHelpText,
   parseOperatorInput,
@@ -89,7 +90,7 @@ let threadDetailMode: "minimal" | "compact" | "verbose" = "minimal";
 let lastRenderedThreadSignature = "";
 
 const screen = blessed.screen({
-  smartCSR: true,
+  smartCSR: process.platform !== "win32",
   dockBorders: true,
   fullUnicode: true,
   autoPadding: false,
@@ -964,11 +965,13 @@ function renderComposer(): void {
 
 function syncNativeCursorPosition(): void {
   if (!isComposerFocused()) {
+    originalHideCursor();
     return;
   }
 
   const coords = composerInput._getCoords?.();
   if (!coords || typeof coords.xi !== "number" || typeof coords.yi !== "number") {
+    originalHideCursor();
     return;
   }
 
@@ -989,7 +992,6 @@ function renderAll(): void {
   renderRooms();
   renderThread();
   renderComposer();
-  originalHideCursor();
   screen.render();
   syncNativeCursorPosition();
 }
@@ -1291,9 +1293,11 @@ async function loadRoomFromHistory(conversationId: string): Promise<OperatorRoom
     return null;
   }
 
-  const participantIds = Array.from(
-    new Set(history.messages.flatMap((message) => [message.from_id, message.to_id]))
-  ).filter((agentId) => agentId !== myId);
+  const participantIds = resolveRoomParticipantIds(
+    history.messages,
+    myId,
+    agentCache.keys()
+  );
 
   if (participantIds.length === 0) {
     return null;
@@ -1449,14 +1453,6 @@ async function pollInbox(): Promise<void> {
       noteMessageConversation(message);
     }
 
-    await acknowledgeMessagesCompatible(BROKER_URL, {
-      id: myId,
-      message_ids: response.messages.map((message) => message.id),
-      auth_token: authToken,
-    });
-
-    await refreshAgents();
-
     const affectsCurrentContext = response.messages.some(messageBelongsToCurrentContext);
     const newest = response.messages.at(-1);
     if (newest) {
@@ -1466,8 +1462,15 @@ async function pollInbox(): Promise<void> {
     if (affectsCurrentContext) {
       await loadCurrentHistory();
     } else {
+      await refreshAgents();
       renderAll();
     }
+
+    await acknowledgeMessagesCompatible(BROKER_URL, {
+      id: myId,
+      message_ids: response.messages.map((message) => message.id),
+      auth_token: authToken,
+    });
   } catch (error) {
     showError(`Inbox poll failed: ${error instanceof Error ? error.message : String(error)}`);
   } finally {
@@ -1742,6 +1745,14 @@ function wireKeyboardShortcuts(): void {
     });
   });
 
+  screen.key(["f10"], () => {
+    if (helpModalOpen) {
+      return;
+    }
+
+    void shutdown(0);
+  });
+
   screen.key(["a"], () => {
     if (helpModalOpen || isComposerFocused()) {
       return;
@@ -1819,8 +1830,6 @@ function wireKeyboardShortcuts(): void {
     }
 
     if (key.name === "escape") {
-      clearComposerDraft();
-      composerEditing = false;
       focusPane("agents");
       return;
     }

--- a/shared/operator-command.test.ts
+++ b/shared/operator-command.test.ts
@@ -116,6 +116,9 @@ test("help text documents the operator slash commands", () => {
   expect(operatorHelpText()).toContain("/leave");
   expect(operatorHelpText()).toContain("/reply");
   expect(operatorHelpText()).toContain("/details [minimal|compact|verbose]");
+  expect(operatorHelpText()).toContain("/exit");
+  expect(operatorHelpText()).toContain("Esc leaves edit mode and preserves the current draft");
+  expect(operatorHelpText()).toContain("F10 quits immediately");
   expect(operatorHelpText()).toContain("v cycles minimal, compact, and verbose message details");
   expect(operatorHelpText()).toContain('/msg "Codex @ claudy-talky" "Need a quick status?"');
   expect(operatorHelpText()).toContain("Plain text sends to the current DM or room.");

--- a/shared/operator-command.ts
+++ b/shared/operator-command.ts
@@ -184,15 +184,17 @@ return `Slash commands:
 /history [limit]
 /context
 /quit
+/exit
 
 Plain text sends to the current DM or room.
 
 Keyboard:
 Tab / Shift+Tab cycle panes
+Ctrl+A jumps straight to the Actions strip
 Left / Right move across the Actions strip
 Enter runs the selected Action or sends the composer text
-Esc clears the composer and leaves edit mode
-Ctrl+A jumps straight to the Actions strip
+Esc leaves edit mode and preserves the current draft
+F10 quits immediately
 x jumps to the Actions strip
 v cycles minimal, compact, and verbose message details
 

--- a/shared/operator-room.test.ts
+++ b/shared/operator-room.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test";
+import { resolveRoomParticipantIds } from "./operator-room.ts";
+import type { Message } from "./types.ts";
+
+function message(
+  id: number,
+  from_id: string,
+  to_id: string,
+  conversation_id = "conv-1"
+): Message {
+  return {
+    id,
+    from_id,
+    to_id,
+    text: `message-${id}`,
+    sent_at: `2026-04-02T12:00:0${id}.000Z`,
+    conversation_id,
+    reply_to_message_id: null,
+    delivered: true,
+    delivered_at: null,
+    surfaced_at: null,
+    opened_at: null,
+    seen_at: null,
+  };
+}
+
+test("prefers currently online room participants when rebuilding from history", () => {
+  const messages = [
+    message(1, "me", "claude"),
+    message(2, "claude", "codex"),
+    message(3, "antigravity", "me"),
+  ];
+
+  expect(resolveRoomParticipantIds(messages, "me", ["claude", "codex"])).toEqual([
+    "claude",
+    "codex",
+  ]);
+});
+
+test("falls back to historical participants when no preferred live participants exist", () => {
+  const messages = [
+    message(1, "me", "claude"),
+    message(2, "claude", "antigravity"),
+    message(3, "gemini", "me"),
+  ];
+
+  expect(resolveRoomParticipantIds(messages, "me", [])).toEqual([
+    "claude",
+    "antigravity",
+    "gemini",
+  ]);
+});

--- a/shared/operator-room.ts
+++ b/shared/operator-room.ts
@@ -1,0 +1,22 @@
+import type { Message } from "./types.ts";
+
+export function resolveRoomParticipantIds(
+  messages: Message[],
+  myId: string,
+  liveAgentIds: Iterable<string>
+): string[] {
+  const historicalParticipants = Array.from(
+    new Set(messages.flatMap((message) => [message.from_id, message.to_id]))
+  ).filter((agentId) => agentId !== myId);
+
+  if (historicalParticipants.length === 0) {
+    return [];
+  }
+
+  const liveAgentIdSet = new Set(liveAgentIds);
+  const liveParticipants = historicalParticipants.filter((agentId) =>
+    liveAgentIdSet.has(agentId)
+  );
+
+  return liveParticipants.length > 0 ? liveParticipants : historicalParticipants;
+}


### PR DESCRIPTION
## Summary
- stabilize the Blessed operator on Windows Terminal without changing the active operator path
- preserve composer drafts on `Esc` and bind the documented `F10` shutdown shortcut
- prefer live participants when reconstructing rooms, with a fallback to historical participants

## Changes
- gate `smartCSR` off on Windows only
- re-hide the native cursor after render when the composer is unfocused
- make the poll-path agent refresh conditional and move message acknowledgement until after successful UI updates
- add `shared/operator-room.ts` plus regression tests for room participant reconstruction
- update help text and README to match the new `Esc` behavior

## Verification
- `bun install`
- `bun x tsc --noEmit`
- `bun test`

## Notes
- This PR targets `codex/operator-tui`, not `main`, because it builds on the current Blessed operator branch.
- I did not run an interactive manual TUI session in this worktree; the verification here is automated plus code inspection.
