### PR TITLE
Fix operator unread badges

### DIFF
--- a/operator.ts
+++ b/operator.ts
@@ -31,6 +31,12 @@ import {
 import { parseOperatorInput, type OperatorCommand } from "./shared/operator-command.ts";
 import { resolveRoomParticipantIds } from "./shared/operator-room.ts";
 import {
+  addPendingUnreadEntries,
+  clearPendingUnreadForMessages,
+  countPendingUnreadByAgent,
+  type PendingUnreadEntry,
+} from "./shared/operator-unread.ts";
+import {
   formatWorkDetailLines,
   formatWorkListLine,
 } from "./shared/work-format.ts";
@@ -78,6 +84,7 @@ type State = {
   detailPanel: DetailPanel;
   threadMode: ThreadMode;
   threadScrollOffset: number;
+  pendingUnread: Map<number, PendingUnreadEntry>;
   pollInFlight: boolean;
   shuttingDown: boolean;
 };
@@ -109,6 +116,7 @@ const initialState: State = {
   detailPanel: null,
   threadMode: "minimal",
   threadScrollOffset: 0,
+  pendingUnread: new Map(),
   pollInFlight: false,
   shuttingDown: false,
 };
@@ -243,8 +251,9 @@ function Panel(props: {
 }
 
 function sortedAgents(state: State): Agent[] {
+  const unreadByAgent = countPendingUnreadByAgent(state.pendingUnread);
   return [...state.agentCache.values()].sort((left, right) => {
-    const unreadDelta = right.unread_count - left.unread_count;
+    const unreadDelta = (unreadByAgent.get(right.id) ?? 0) - (unreadByAgent.get(left.id) ?? 0);
     if (unreadDelta !== 0) return unreadDelta;
     return left.name.localeCompare(right.name);
   });
@@ -344,7 +353,14 @@ function App(): ReactElement {
     else request.conversation_id = current.currentContext.conversationId;
     const history = await messageHistoryCompatible(BROKER_URL, request);
     await refreshAgents();
-    updateState((prev) => ({ ...prev, currentMessages: sortMessages(history.messages), currentLimit: limit, detailPanel: null, threadScrollOffset: 0 }));
+    updateState((prev) => ({
+      ...prev,
+      currentMessages: sortMessages(history.messages),
+      currentLimit: limit,
+      detailPanel: null,
+      threadScrollOffset: 0,
+      pendingUnread: clearPendingUnreadForMessages(prev.pendingUnread, prev.myId, history.messages),
+    }));
   }, [refreshAgents, updateState]);
 
   const showDetail = useCallback((title: string, lines: string[]) => {
@@ -786,6 +802,9 @@ function App(): ReactElement {
       );
       const nextDmConversations = new Map(prev.dmConversations);
       nextDmConversations.delete(agentId);
+      const nextPendingUnread = new Map(
+        [...prev.pendingUnread.entries()].filter(([, entry]) => entry.fromId !== agentId)
+      );
 
       const nextState: State = {
         ...prev,
@@ -793,6 +812,7 @@ function App(): ReactElement {
         agentRefs: nextAgentRefs,
         rooms: nextRooms,
         dmConversations: nextDmConversations,
+        pendingUnread: nextPendingUnread,
         selectedAgentId:
           prev.selectedAgentId === agentId
             ? nextAgentRefs[0]?.agent.id ?? null
@@ -929,6 +949,31 @@ function App(): ReactElement {
         }
       }
       const ctx = stateRef.current.currentContext;
+      const trackableUnread = response.messages
+        .filter((message) => message.to_id === stateRef.current.myId && message.from_id !== stateRef.current.myId)
+        .filter((message) =>
+          ctx.kind === "room"
+            ? message.conversation_id !== ctx.conversationId
+            : ctx.kind === "dm"
+              ? !(
+                  (message.from_id === ctx.agentId && message.to_id === stateRef.current.myId) ||
+                  (message.from_id === stateRef.current.myId && message.to_id === ctx.agentId)
+                )
+              : true
+        )
+        .map((message) => ({
+          messageId: message.id,
+          fromId: message.from_id,
+          conversationId: message.conversation_id,
+        }));
+
+      if (trackableUnread.length > 0) {
+        updateState((prev) => ({
+          ...prev,
+          pendingUnread: addPendingUnreadEntries(prev.pendingUnread, trackableUnread),
+        }));
+      }
+
       const affectsCurrent =
         ctx.kind === "room"
           ? response.messages.some((message) => message.conversation_id === ctx.conversationId)
@@ -1066,6 +1111,7 @@ function App(): ReactElement {
   }, [size]);
 
   const agentRows = useMemo(() => {
+    const unreadByAgent = countPendingUnreadByAgent(state.pendingUnread);
     const rows = sortedAgents(state);
     const index = Math.max(0, rows.findIndex((row) => row.id === state.selectedAgentId));
     const visibleRows: { id: string; text: string; selected: boolean }[] =
@@ -1074,7 +1120,7 @@ function App(): ReactElement {
         : windowAround(
             rows.map((agent) => ({
               id: agent.id,
-              text: `${participantRef(agent.id) ?? agent.id}${agent.unread_count > 0 ? ` [${agent.unread_count}]` : ""} ${agent.name}`,
+              text: `${participantRef(agent.id) ?? agent.id}${(unreadByAgent.get(agent.id) ?? 0) > 0 ? ` [${unreadByAgent.get(agent.id)}]` : ""} ${agent.name}`,
               selected: agent.id === state.selectedAgentId,
             })),
             index,

--- a/shared/operator-unread.test.ts
+++ b/shared/operator-unread.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "bun:test";
+import {
+  addPendingUnreadEntries,
+  clearPendingUnreadForMessages,
+  countPendingUnreadByAgent,
+} from "./operator-unread.ts";
+import type { Message } from "./types.ts";
+
+function message(overrides: Partial<Message>): Message {
+  return {
+    id: 1,
+    from_id: "from",
+    to_id: "me",
+    text: "hello",
+    sent_at: "2026-04-02T00:00:00.000Z",
+    conversation_id: "conv-1",
+    reply_to_message_id: null,
+    delivered: true,
+    delivered_at: null,
+    surfaced_at: null,
+    opened_at: null,
+    seen_at: null,
+    ...overrides,
+  };
+}
+
+test("counts pending unread messages by sender", () => {
+  const pending = addPendingUnreadEntries(new Map(), [
+    { messageId: 1, fromId: "claude", conversationId: "conv-a" },
+    { messageId: 2, fromId: "claude", conversationId: "conv-a" },
+    { messageId: 3, fromId: "codex", conversationId: "conv-b" },
+  ]);
+
+  expect(countPendingUnreadByAgent(pending)).toEqual(
+    new Map([
+      ["claude", 2],
+      ["codex", 1],
+    ])
+  );
+});
+
+test("clears only inbound unread messages that are present in opened history", () => {
+  const pending = addPendingUnreadEntries(new Map(), [
+    { messageId: 1, fromId: "claude", conversationId: "conv-a" },
+    { messageId: 2, fromId: "claude", conversationId: "conv-b" },
+    { messageId: 3, fromId: "codex", conversationId: "conv-c" },
+  ]);
+
+  const next = clearPendingUnreadForMessages(pending, "me", [
+    message({ id: 2, from_id: "claude", to_id: "me", conversation_id: "conv-b" }),
+    message({ id: 99, from_id: "me", to_id: "claude", conversation_id: "conv-b" }),
+  ]);
+
+  expect(Array.from(next.keys())).toEqual([1, 3]);
+  expect(countPendingUnreadByAgent(next)).toEqual(
+    new Map([
+      ["claude", 1],
+      ["codex", 1],
+    ])
+  );
+});

--- a/shared/operator-unread.ts
+++ b/shared/operator-unread.ts
@@ -1,0 +1,51 @@
+import type { Message } from "./types.ts";
+
+export type PendingUnreadEntry = {
+  messageId: number;
+  fromId: string;
+  conversationId: string;
+};
+
+export function addPendingUnreadEntries(
+  current: Map<number, PendingUnreadEntry>,
+  entries: PendingUnreadEntry[]
+): Map<number, PendingUnreadEntry> {
+  if (entries.length === 0) {
+    return current;
+  }
+
+  const next = new Map(current);
+  for (const entry of entries) {
+    next.set(entry.messageId, entry);
+  }
+  return next;
+}
+
+export function clearPendingUnreadForMessages(
+  current: Map<number, PendingUnreadEntry>,
+  myId: string,
+  messages: Message[]
+): Map<number, PendingUnreadEntry> {
+  if (current.size === 0 || messages.length === 0) {
+    return current;
+  }
+
+  const next = new Map(current);
+  for (const message of messages) {
+    if (message.to_id !== myId || message.from_id === myId) {
+      continue;
+    }
+    next.delete(message.id);
+  }
+  return next;
+}
+
+export function countPendingUnreadByAgent(
+  current: Map<number, PendingUnreadEntry>
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const entry of current.values()) {
+    counts.set(entry.fromId, (counts.get(entry.fromId) ?? 0) + 1);
+  }
+  return counts;
+}


### PR DESCRIPTION
## Summary
- replace agent-row unread badges with operator-local unread-by-sender state
- increment badges only for inbound messages outside the currently open thread
- clear badge state when the relevant DM or room history is opened

## Rationale
The operator was rendering each agent's broker unread count, which describes that agent's own inbox rather than new messages sent to the operator. The badge source of truth had to move into the operator.

## User Impact
- agent badges now reflect new messages from that sender to the current operator session
- opening the relevant thread clears the badge as expected
- removing an agent also clears its local badge state

## Verification
- bun x tsc --noEmit
- bun test