### PR TITLE
Add operator tasks action

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Slash commands still work in the composer:
 
 ```text
 /agents
+/tasks
 /details [minimal|compact|verbose]
 /dm <agent-ref-or-name> [message]
 /msg <agent-ref-or-name> <message>
@@ -153,6 +154,7 @@ Plain text in the composer sends to the current DM or room.
 
 The operator and CLI adapters support a lightweight broker-backed work layer on top of normal threads:
 
+- `/tasks`
 - `/queue Investigate stale operator registrations`
 - `/queue-work Investigate stale operator registrations`
 - `/handoff codex Investigate stale operator registrations`
@@ -172,6 +174,8 @@ The operator and CLI adapters support a lightweight broker-backed work layer on 
 - `/update-work-status 12 block Waiting on broker logs`
 
 Handoffs stay linked to the current DM or room conversation when one is active, so the work item and its discussion stay tied together.
+
+The operator also has a `[T] Tasks` action that opens a grouped task overview in the thread/detail view, so queued, assigned, active, and blocked work can be inspected without leaving the current operator UI.
 
 Ownership is enforced at the broker:
 

--- a/operator.ts
+++ b/operator.ts
@@ -151,6 +151,7 @@ function windowAround<T>(items: T[], selectedIndex: number, count: number): T[] 
 function helpLines(): string[] {
   return [
     "Slash commands: /help /leave /agents /rooms /reply /details [minimal|compact|verbose]",
+    "/tasks",
     "/queue <summary> /queue-work <summary>",
     "/handoff <agent> <summary> /handoff-work <agent> <summary>",
     "/assign <work-id> <agent> [note] /assign-work <work-id> <agent> [note] /requeue <work-id> [note]",
@@ -174,6 +175,7 @@ const ACTION_ITEMS = [
   { label: "Reply", shortcut: "R" },
   { label: "Leave", shortcut: "L" },
   { label: "Refresh", shortcut: "F" },
+  { label: "Tasks", shortcut: "T" },
   { label: "Remove agent", shortcut: "X" },
   { label: "Help", shortcut: "H" },
 ] as const;
@@ -607,6 +609,50 @@ function App(): ReactElement {
     showDetail(`Work (${filter})`, lines);
   }, [brokerPost, participantDisplay, showDetail]);
 
+  const showTasksOverview = useCallback(async () => {
+    const current = stateRef.current;
+    const result = await brokerPost<ListWorkResponse>("/list-work", {
+      agent_id: current.myId,
+      include_done: false,
+      limit: 100,
+      auth_token: current.authToken,
+    });
+
+    const sections: Array<{ title: string; items: typeof result.work_items }> = [
+      { title: "Queued", items: result.work_items.filter((work) => work.status === "queued") },
+      { title: "Assigned", items: result.work_items.filter((work) => work.status === "assigned") },
+      { title: "Active", items: result.work_items.filter((work) => work.status === "active") },
+      { title: "Blocked", items: result.work_items.filter((work) => work.status === "blocked") },
+    ];
+
+    const lines: string[] = [
+      "Quick commands:",
+      "- /work <id> or /get-work <id>",
+      "- /take <id>",
+      "- /assign <id> <agent> [note]",
+      "- /requeue <id> [note]",
+      "- /block <id> <reason>",
+      "- /done <id> [note]",
+    ];
+
+    const total = sections.reduce((count, section) => count + section.items.length, 0);
+    if (total === 0) {
+      lines.push("", "No active tasks.");
+    } else {
+      for (const section of sections) {
+        if (section.items.length === 0) {
+          continue;
+        }
+        lines.push("", `${section.title}:`);
+        for (const work of section.items) {
+          lines.push(`- ${formatWorkListLine(work, participantDisplay)}`);
+        }
+      }
+    }
+
+    showDetail("Tasks", lines);
+  }, [brokerPost, participantDisplay, showDetail]);
+
   const queueWork = useCallback(async (summary: string) => {
     const current = stateRef.current;
     const result = await brokerPost<QueueWorkResponse>("/queue-work", {
@@ -854,6 +900,9 @@ function App(): ReactElement {
       case "F":
         await fullRefresh();
         return;
+      case "T":
+        await showTasksOverview();
+        return;
       case "X":
         await removeAgentFromBroker(stateRef.current.selectedAgentId ?? "");
         return;
@@ -869,6 +918,7 @@ function App(): ReactElement {
       case "quit": await shutdown(0); return;
       case "leave": leaveContext(); return;
       case "reply": await switchReplyContext(); return;
+      case "tasks": await showTasksOverview(); return;
       case "queue": await queueWork(command.summary); return;
       case "handoff": await handoffWork(command.agentSelector, command.summary); return;
       case "assign": await assignWork(command.workId, command.agentSelector, command.note); return;
@@ -904,7 +954,7 @@ function App(): ReactElement {
         throw new Error(`Unhandled command: ${String(neverReached)}`);
       }
     }
-  }, [assignWork, createRoom, handoffWork, leaveContext, queueWork, refreshAgents, removeAgentFromBroker, sendInCurrentContext, setNotice, showContext, showHistory, showParticipants, showDetail, showWorkDetail, showWorkList, shutdown, switchDm, switchReplyContext, updateState, updateWorkStatus, useRoom]);
+  }, [assignWork, createRoom, handoffWork, leaveContext, queueWork, refreshAgents, removeAgentFromBroker, sendInCurrentContext, setNotice, showContext, showHistory, showParticipants, showDetail, showTasksOverview, showWorkDetail, showWorkList, shutdown, switchDm, switchReplyContext, updateState, updateWorkStatus, useRoom]);
 
   const handleSubmit = useCallback(async (rawValue: string) => {
     const value = rawValue.trim();

--- a/shared/operator-command.test.ts
+++ b/shared/operator-command.test.ts
@@ -27,6 +27,10 @@ test("parses DM and room slash commands", () => {
     kind: "reply",
   });
 
+  expect(parseOperatorInput("/tasks")).toEqual({
+    kind: "tasks",
+  });
+
   expect(parseOperatorInput("/handoff codex Fix operator scroll UX")).toEqual({
     kind: "handoff",
     agentSelector: "codex",
@@ -299,6 +303,7 @@ test("rejects invalid room and history usage", () => {
 });
 
 test("help text documents the operator slash commands", () => {
+  expect(operatorHelpText()).toContain("/tasks");
   expect(operatorHelpText()).toContain("/handoff <agent-ref-or-name> <summary>");
   expect(operatorHelpText()).toContain("/handoff-work <agent-ref-or-name> <summary>");
   expect(operatorHelpText()).toContain("/queue <summary>");

--- a/shared/operator-command.ts
+++ b/shared/operator-command.ts
@@ -3,6 +3,7 @@ export type OperatorCommand =
   | { kind: "quit" }
   | { kind: "leave" }
   | { kind: "reply" }
+  | { kind: "tasks" }
   | { kind: "handoff"; agentSelector: string; summary: string }
   | { kind: "queue"; summary: string }
   | { kind: "assign"; workId: number; agentSelector: string; note?: string }
@@ -114,6 +115,8 @@ export function parseOperatorInput(line: string): OperatorCommand {
       return { kind: "leave" };
     case "reply":
       return { kind: "reply" };
+    case "tasks":
+      return { kind: "tasks" };
     case "handoff":
     case "handoff-work":
       return subcommand && rest.length > 0
@@ -299,6 +302,7 @@ return `Slash commands:
 /help
 /leave
 /agents
+/tasks
 /queue <summary>
 /queue-work <summary>
 /handoff <agent-ref-or-name> <summary>


### PR DESCRIPTION
## Summary
- add a `[T] Tasks` action to the Ink operator action strip
- add a `/tasks` alias that opens the same grouped task overview
- show queued, assigned, active, and blocked work in the existing detail panel with quick command hints

## Rationale
The operator already had the work commands, but no concise task overview in the UI. This adds a lightweight task control surface without introducing a new pane or scheduler UI.

## User Impact
- operators can open a grouped task overview directly from the action strip
- `/tasks` provides the same entry point from the composer
- the overview keeps task inspection and follow-up commands inside the current operator workflow

## Verification
- bun x tsc --noEmit
- bun test