### PR TITLE
Pin dependency versions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,18 +5,16 @@
     "": {
       "name": "claudy-talky",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.27.1",
-        "@types/react": "19",
+        "@modelcontextprotocol/sdk": "1.29.0",
+        "@types/react": "19.2.14",
         "ink": "6.8.0",
         "ink-text-input": "6.0.0",
-        "react": "19",
-        "react-devtools-core": "^6.1.2",
+        "react": "19.2.4",
+        "react-devtools-core": "6.1.5",
       },
       "devDependencies": {
-        "@types/bun": "latest",
-      },
-      "peerDependencies": {
-        "typescript": "^5",
+        "@types/bun": "1.3.11",
+        "typescript": "5.9.3",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "module": "index.ts",
   "type": "module",
   "private": true,
+  "packageManager": "bun@1.3.11",
   "scripts": {
     "broker": "bun broker.ts",
     "server": "bun server.ts",
@@ -22,17 +23,15 @@
     "test": "bun test"
   },
   "devDependencies": {
-    "@types/bun": "latest"
-  },
-  "peerDependencies": {
-    "typescript": "^5"
+    "@types/bun": "1.3.11",
+    "typescript": "5.9.3"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.1",
-    "@types/react": "19",
+    "@modelcontextprotocol/sdk": "1.29.0",
+    "@types/react": "19.2.14",
     "ink": "6.8.0",
     "ink-text-input": "6.0.0",
-    "react": "19",
-    "react-devtools-core": "^6.1.2"
+    "react": "19.2.4",
+    "react-devtools-core": "6.1.5"
   }
 }


### PR DESCRIPTION
## Summary
- pin Bun package manager version in `package.json`
- pin the current TypeScript, MCP SDK, React, Ink, and Bun type versions
- refresh `bun.lock` against the pinned manifest

## Rationale
This removes broad semver ranges and `latest` from the repo's primary runtime and UI stack so dependency resolution is deterministic.

## Verification
- `bun x tsc --noEmit`
- `bun test`
- `agnix validate .`