### PR TITLE
[codex] Add work requeue action and version bump script

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,23 +1,26 @@
 {
   "name": "claudy-talky-marketplace",
-
   "owner": {
     "name": "CyanoTex",
     "url": "https://github.com/CyanoTex"
   },
-
   "metadata": {
     "description": "Shared local broker and MCP bridge for Claude Code, Codex, Gemini, and local agents.",
-    "version": "0.4.0"
+    "version": "0.4.1"
   },
-
   "plugins": [
     {
       "name": "claudy-talky",
       "description": "Let Claude Code talk to Codex, Gemini, and local agents through a shared local broker with messaging, work handoff, agent discovery, and instant channel notifications.",
       "source": "./",
       "category": "external-integrations",
-      "tags": ["mcp", "broker", "multi-agent", "codex", "gemini"]
+      "tags": [
+        "mcp",
+        "broker",
+        "multi-agent",
+        "codex",
+        "gemini"
+      ]
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claudy-talky",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Shared local broker and MCP bridge for Claude Code, Codex, Gemini, and local agents.",
   "author": {
     "name": "CyanoTex",

--- a/README.md
+++ b/README.md
@@ -131,14 +131,14 @@ The MCP adapters support a lightweight broker-backed work layer on top of normal
 - `list_work` filters active or historical work by owner, status, or conversation.
 - `get_work` shows one work item and its event history.
 - `assign_work` reassigns work to another agent or returns it to the queue.
-- `update_work_status` marks work taken, blocked, done, or active again.
+- `update_work_status` marks work taken, blocked, done, active again, or requeued.
 
 Handoffs stay linked to the current conversation when one is active, so the work item and its discussion stay tied together.
 
 Ownership is enforced at the broker:
 
 - `take` only works if the work is unassigned or already assigned to you
-- `block`, `done`, and `activate` only work for the current owner
+- `block`, `done`, `activate`, and `requeue` only work for the current owner unless the caller is a work admin
 - agents with `work_admin` capability can reassign work or override ownership transitions when needed
 - queued work uses the explicit `queued` state rather than overloading `assigned`
 
@@ -275,7 +275,7 @@ z.ai looks possible as a provider layer, but not yet as a first-class `claudy-ta
 | `get_work` | Inspect one work item plus its event history |
 | `handoff_work` | Create a work handoff for another agent, optionally linked to a thread |
 | `assign_work` | Reassign work to another agent or return it to the queue |
-| `update_work_status` | Mark a work item taken, blocked, done, or otherwise update its state |
+| `update_work_status` | Mark a work item taken, blocked, done, active again, requeued, or otherwise update its state |
 | `set_summary` | Publish a short description of Claude's current work |
 | `check_messages` | Manually check for inbound messages |
 | `list_peers` | Backward-compatible alias for `list_agents` |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,6 +11,7 @@ This file tracks the remaining follow-up work after the current broker and CLI c
 ## Recently Landed
 
 - Added scan-friendly MCP work item formatting with owner, relative update age, conversation hints, blocker previews, event ages, status-specific next-step guidance, and richer mutation responses after queue, handoff, assign, and status updates.
+- Added `requeue` as a direct `update_work_status` action so owners and work admins can release work back to the queue without switching tools.
 
 ## Suggested Shape
 
@@ -19,7 +20,7 @@ Future follow-up can still split into three layers if needed.
 ### Task UX
 
 - Continue improving task list and detail presentation in MCP tool output where real use exposes gaps.
-- Faster assignment, takeover, and requeue flows where the broker API needs them.
+- Continue refining assignment, takeover, and requeue flows where real use exposes gaps.
 - Clearer task state visibility for polling-based adapters.
 
 ### Collaboration Model

--- a/adapter.cli.e2e.test.ts
+++ b/adapter.cli.e2e.test.ts
@@ -651,6 +651,30 @@ for (const config of CLI_ADAPTERS) {
       );
       expect(workTakeText).toContain(`Updated work #${adapterWorkId} to active.`);
 
+      const workRequeueText = textContent(
+        await session.client.callTool({
+          name: "update_work_status",
+          arguments: {
+            work_id: adapterWorkId,
+            action: "requeue",
+            note: "return to queue in e2e",
+          },
+        })
+      );
+      expect(workRequeueText).toContain(`Updated work #${adapterWorkId} to queued.`);
+      expect(workRequeueText).toContain("owner=queue");
+
+      const workRetakeText = textContent(
+        await session.client.callTool({
+          name: "update_work_status",
+          arguments: {
+            work_id: adapterWorkId,
+            action: "take",
+          },
+        })
+      );
+      expect(workRetakeText).toContain(`Updated work #${adapterWorkId} to active.`);
+
       const workDoneText = textContent(
         await session.client.callTool({
           name: "update_work_status",

--- a/broker.test.ts
+++ b/broker.test.ts
@@ -843,6 +843,22 @@ test("creates handoffs, tracks work state, and records work events", async () =>
   expect(blocked.work?.status).toBe("blocked");
   expect(blocked.work?.blocker_note).toBe("Waiting on repro steps");
 
+  const requeued = await brokerFetch<{
+    ok: boolean;
+    work?: { status: string; owner_id: string | null; blocker_note: string | null };
+  }>("/update-work-status", {
+    agent_id: codex.id,
+    work_id: handoff.work?.id,
+    action: "requeue",
+    note: "Back to the queue",
+    auth_token: codex.auth_token,
+  });
+
+  expect(requeued.ok).toBe(true);
+  expect(requeued.work?.status).toBe("queued");
+  expect(requeued.work?.owner_id).toBeNull();
+  expect(requeued.work?.blocker_note).toBeNull();
+
   const geminiDoneRejected = await brokerFetch<{
     ok: boolean;
     error?: string;
@@ -855,7 +871,7 @@ test("creates handoffs, tracks work state, and records work events", async () =>
   });
 
   expect(geminiDoneRejected.ok).toBe(false);
-  expect(geminiDoneRejected.error).toContain(codex.id);
+  expect(geminiDoneRejected.error).toContain("unassigned");
 
   const adminAssign = await brokerFetch<{
     ok: boolean;
@@ -910,6 +926,7 @@ test("creates handoffs, tracks work state, and records work events", async () =>
     "handoff",
     "take",
     "block",
+    "queue",
     "assign",
     "done",
   ]);

--- a/broker.ts
+++ b/broker.ts
@@ -695,6 +695,7 @@ function normalizeWorkAction(
     case "block":
     case "done":
     case "activate":
+    case "requeue":
       return action;
     default:
       return null;
@@ -1664,6 +1665,22 @@ function handleUpdateWorkStatus(
       nextStatus = "active";
       blockerNote = null;
       eventKind = "status";
+      break;
+    case "requeue":
+      if (
+        !isAdmin &&
+        currentWork.owner_id !== body.agent_id &&
+        !(currentWork.owner_id === null && currentWork.created_by_id === body.agent_id)
+      ) {
+        return {
+          ok: false,
+          error: `Work item #${workId} is owned by ${currentWork.owner_id ?? "the queue"}. Only the owner, queue creator, or a work admin can requeue it.`,
+        };
+      }
+      nextOwnerId = null;
+      nextStatus = "queued";
+      blockerNote = null;
+      eventKind = "queue";
       break;
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudy-talky",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Let Claude Code CLI talk to Codex CLI, Gemini CLI, and local agents through a shared broker",
   "module": "index.ts",
   "type": "module",
@@ -9,6 +9,7 @@
   "scripts": {
     "broker": "bun broker.ts",
     "server": "bun server.ts",
+    "version:bump": "bun version.ts",
     "setup": "bun setup.ts install cli --scope user",
     "setup:project": "bun setup.ts install cli --scope project",
     "setup:all": "bun setup.ts install all --scope user",

--- a/server.ts
+++ b/server.ts
@@ -340,7 +340,7 @@ Available tools:
 - get_work: Inspect one work item in detail
 - handoff_work: Hand work to another agent and notify them
 - assign_work: Reassign work to another agent or return it to the queue
-- update_work_status: Take, block, or complete a work item
+- update_work_status: Take, block, complete, activate, or requeue a work item
 - set_summary: Set a 1-2 sentence summary of what you're working on
 - check_messages: Manually check for new messages
 
@@ -566,7 +566,7 @@ const TOOLS = [
   {
     name: "update_work_status",
     description:
-      "Update a work item by taking it, blocking it, marking it done, or returning it to active.",
+      "Update a work item by taking it, blocking it, marking it done, returning it to active, or requeueing it.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -576,7 +576,7 @@ const TOOLS = [
         },
         action: {
           type: "string" as const,
-          enum: ["take", "block", "done", "activate"],
+          enum: ["take", "block", "done", "activate", "requeue"],
           description: "Status transition to apply.",
         },
         note: {
@@ -1167,7 +1167,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
       try {
         const { work_id, action, note } = args as {
           work_id: number;
-          action: "take" | "block" | "done" | "activate";
+          action: "take" | "block" | "done" | "activate" | "requeue";
           note?: string;
         };
 

--- a/shared/polling-adapter.ts
+++ b/shared/polling-adapter.ts
@@ -494,7 +494,7 @@ export async function runPollingAdapter(
     {
       name: "update_work_status",
       description:
-        "Update a work item by taking it, blocking it, marking it done, or returning it to active.",
+        "Update a work item by taking it, blocking it, marking it done, returning it to active, or requeueing it.",
       inputSchema: {
         type: "object" as const,
         properties: {
@@ -504,7 +504,7 @@ export async function runPollingAdapter(
           },
           action: {
             type: "string" as const,
-            enum: ["take", "block", "done", "activate"],
+            enum: ["take", "block", "done", "activate", "requeue"],
             description: "Status transition to apply.",
           },
           note: {
@@ -1294,7 +1294,7 @@ export async function runPollingAdapter(
         try {
           const { work_id, action, note } = args as {
             work_id: number;
-            action: "take" | "block" | "done" | "activate";
+            action: "take" | "block" | "done" | "activate" | "requeue";
             note?: string;
           };
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -260,7 +260,7 @@ export interface AssignWorkResponse {
 export interface UpdateWorkStatusRequest {
   agent_id: AgentId;
   work_id: number;
-  action: "take" | "block" | "done" | "activate";
+  action: "take" | "block" | "done" | "activate" | "requeue";
   note?: string | null;
   auth_token?: string;
 }

--- a/shared/version-bump.test.ts
+++ b/shared/version-bump.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test";
+
+import {
+  assertValidVersion,
+  updateVersionFile,
+} from "./version-bump.ts";
+
+test("updateVersionFile updates package.json version", () => {
+  const result = updateVersionFile(
+    "packageJson",
+    JSON.stringify({ name: "claudy-talky", version: "0.4.0" }),
+    "0.4.1"
+  );
+
+  expect(result.previousVersion).toBe("0.4.0");
+  expect(result.nextVersion).toBe("0.4.1");
+  expect(JSON.parse(result.contents)).toEqual({
+    name: "claudy-talky",
+    version: "0.4.1",
+  });
+});
+
+test("updateVersionFile updates Claude plugin version", () => {
+  const result = updateVersionFile(
+    "claudePluginJson",
+    JSON.stringify({ name: "claudy-talky", version: "0.4.0" }),
+    "0.4.1"
+  );
+
+  expect(result.path).toBe(".claude-plugin/plugin.json");
+  expect(JSON.parse(result.contents).version).toBe("0.4.1");
+});
+
+test("updateVersionFile updates Claude marketplace metadata version", () => {
+  const result = updateVersionFile(
+    "claudeMarketplaceJson",
+    JSON.stringify({
+      name: "claudy-talky-marketplace",
+      metadata: { version: "0.4.0" },
+    }),
+    "0.4.1"
+  );
+
+  expect(result.path).toBe(".claude-plugin/marketplace.json");
+  expect(JSON.parse(result.contents).metadata.version).toBe("0.4.1");
+});
+
+test("assertValidVersion rejects non-semver input", () => {
+  expect(() => assertValidVersion("next")).toThrow("Version must be semver-like");
+  expect(() => assertValidVersion("1.2")).toThrow("Version must be semver-like");
+});
+

--- a/shared/version-bump.ts
+++ b/shared/version-bump.ts
@@ -1,0 +1,106 @@
+export const VERSION_FILE_PATHS = {
+  packageJson: "package.json",
+  claudePluginJson: ".claude-plugin/plugin.json",
+  claudeMarketplaceJson: ".claude-plugin/marketplace.json",
+} as const;
+
+export type VersionFileKind = keyof typeof VERSION_FILE_PATHS;
+
+export interface VersionUpdate {
+  kind: VersionFileKind;
+  path: string;
+  previousVersion: string;
+  nextVersion: string;
+  contents: string;
+}
+
+export function isValidVersion(version: string): boolean {
+  return /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(version);
+}
+
+export function assertValidVersion(version: string): void {
+  if (!isValidVersion(version)) {
+    throw new Error(`Version must be semver-like, for example 0.4.1. Received: ${version}`);
+  }
+}
+
+function parseJsonObject(contents: string, path: string): Record<string, unknown> {
+  const parsed = JSON.parse(contents) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${path} must contain a JSON object`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function stringifyJson(contents: Record<string, unknown>): string {
+  return `${JSON.stringify(contents, null, 2)}\n`;
+}
+
+function updateTopLevelVersion(
+  kind: VersionFileKind,
+  path: string,
+  contents: string,
+  version: string
+): VersionUpdate {
+  const document = parseJsonObject(contents, path);
+  const previousVersion = document.version;
+  if (typeof previousVersion !== "string") {
+    throw new Error(`${path} must contain a top-level string version`);
+  }
+
+  document.version = version;
+
+  return {
+    kind,
+    path,
+    previousVersion,
+    nextVersion: version,
+    contents: stringifyJson(document),
+  };
+}
+
+function updateMarketplaceVersion(
+  contents: string,
+  version: string
+): VersionUpdate {
+  const path = VERSION_FILE_PATHS.claudeMarketplaceJson;
+  const document = parseJsonObject(contents, path);
+  const metadata = document.metadata;
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    throw new Error(`${path} must contain a metadata object`);
+  }
+
+  const metadataObject = metadata as Record<string, unknown>;
+  const previousVersion = metadataObject.version;
+  if (typeof previousVersion !== "string") {
+    throw new Error(`${path} must contain a metadata.version string`);
+  }
+
+  metadataObject.version = version;
+
+  return {
+    kind: "claudeMarketplaceJson",
+    path,
+    previousVersion,
+    nextVersion: version,
+    contents: stringifyJson(document),
+  };
+}
+
+export function updateVersionFile(
+  kind: VersionFileKind,
+  contents: string,
+  version: string
+): VersionUpdate {
+  assertValidVersion(version);
+
+  switch (kind) {
+    case "packageJson":
+      return updateTopLevelVersion(kind, VERSION_FILE_PATHS.packageJson, contents, version);
+    case "claudePluginJson":
+      return updateTopLevelVersion(kind, VERSION_FILE_PATHS.claudePluginJson, contents, version);
+    case "claudeMarketplaceJson":
+      return updateMarketplaceVersion(contents, version);
+  }
+}
+

--- a/version.ts
+++ b/version.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env bun
+
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import {
+  VERSION_FILE_PATHS,
+  assertValidVersion,
+  updateVersionFile,
+  type VersionFileKind,
+} from "./shared/version-bump.ts";
+
+const version = process.argv[2];
+
+if (!version) {
+  console.error("Usage: bun version.ts <version>");
+  process.exit(1);
+}
+
+try {
+  assertValidVersion(version);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}
+
+const updateOrder = Object.keys(VERSION_FILE_PATHS) as VersionFileKind[];
+
+for (const kind of updateOrder) {
+  const relativePath = VERSION_FILE_PATHS[kind];
+  const absolutePath = resolve(process.cwd(), relativePath);
+  const contents = await readFile(absolutePath, "utf8");
+  const update = updateVersionFile(kind, contents, version);
+
+  if (update.contents !== contents) {
+    await writeFile(absolutePath, update.contents);
+  }
+
+  console.log(`${update.path}: ${update.previousVersion} -> ${update.nextVersion}`);
+}
+


### PR DESCRIPTION
## Summary
- add `requeue` as a direct `update_work_status` action so owners and work admins can release work back to the queue without switching tools
- update the Claude and polling adapter schemas and tool descriptions to expose the new action
- add a reusable version bump utility plus `bun run version:bump -- <version>` so `package.json` and Claude plugin metadata stay in sync
- bump the repo/plugin version to `0.4.1` so Claude Code marketplace updates can pick up the new action

## Why
Claude’s smoke test showed `/plugin update` was still pinned to `0.4.0` and the new action was not visible until the branch and metadata were published. Automating the version bump removes that drift and keeps the marketplace/plugin metadata aligned with the repo version.

## Impact
- `update_work_status` now supports `requeue`
- the broker can move work from active back to queued in one tool call
- Claude, Codex, and Gemini all expose the same action through their MCP tool definitions
- future version bumps can be applied consistently with a single script

## Verification
- `bun run version:bump -- 0.4.1`
- `bun x tsc --noEmit`
- `bun test` (`40 pass, 0 fail`)