### PR TITLE
[codex] Remove redundant Claude project config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "claudy-talky": {
-      "command": "bun",
-      "args": ["./server.ts"]
-    }
-  }
-}

--- a/README.md
+++ b/README.md
@@ -91,13 +91,14 @@ bun setup
 ### 2. Register Claude Code CLI
 
 ```bash
-claude mcp add --scope user --transport stdio claudy-talky -- bun <repo-root>/server.ts
+claude plugin marketplace add CyanoTex/claudy-talky
+claude plugin install claudy-talky@claudy-talky-marketplace
 ```
 
 ### 3. Start Claude Code CLI with channels enabled
 
 ```bash
-claude --dangerously-load-development-channels server:claudy-talky
+claude --dangerously-load-development-channels plugin:claudy-talky@claudy-talky-marketplace
 ```
 
 ### 4. Ask Claude to inspect the local agent network
@@ -163,9 +164,9 @@ bun setup.ts install all --scope user
 
 Notes:
 
-- `project` scope updates the repo-local config files in this checkout.
+- `project` scope updates the repo-local config files in this checkout for Codex and Gemini.
 - `user` scope writes the usual user config files for Codex and Gemini.
-- Claude currently stays project-scoped and updates `.mcp.json` in the repo root.
+- Claude uses the marketplace plugin path instead of a repo-root `.mcp.json`.
 
 ## Connect Codex CLI
 


### PR DESCRIPTION
## Summary
- remove the redundant repo-root `.mcp.json` Claude registration
- update the README to point Claude users at the marketplace/plugin path only
- keep Codex and Gemini project-scoped config guidance unchanged

## Why
Claude had a second, stale registration surface that was redundant with the marketplace plugin and caused double-registration confusion during smoke testing.

## Impact
- there is now one Claude install path in the repo docs: the marketplace plugin
- the repo no longer carries a duplicate Claude MCP config at `.mcp.json`
- the README no longer tells users to rely on the old repo-root Claude config

## Verification
- docs/config-only change
- `git status` clean after commit