### PR TITLE
[codex] Tighten AGENTS Claude config notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - Shared broker, protocol, formatting, and setup code lives in `shared/`.
 - Example integrations live in `examples/`.
 - Tests live at the repo root and under `shared/`; follow existing names such as `broker.test.ts` and `shared/config.test.ts`.
+- Claude uses the marketplace plugin path in `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`; there is no repo-root `.mcp.json`.
 - Remaining repo-level follow-up work lives in `ROADMAP.md`.
 
 ## Setup Commands
@@ -16,6 +17,7 @@
 - Start the Codex adapter: `bun codex-server.ts`
 - Start the Gemini adapter: `bun google-server.ts`
 - List connected agents: `bun cli.ts agents`
+- Bump the package and plugin versions together with `bun run version:bump -- <version>`.
 
 ## Code Style
 - Use TypeScript with ESM imports and 2-space indentation.


### PR DESCRIPTION
## Summary
- update AGENTS.md to describe the Claude marketplace/plugin path instead of a repo-root `.mcp.json`
- document `bun run version:bump -- <version>` as the supported way to keep package and plugin versions aligned

## Why
The repo no longer carries a standalone Claude project config, and the versioning workflow now needs to be explicit for future plugin updates.

## Impact
- AGENTS.md now matches the actual Claude install path
- future version bumps are easier for agents to perform consistently

## Verification
- `bun x agnix validate .` → 0 errors, 1 warning
- `git status` clean after commit